### PR TITLE
Simple-SDS serialization format

### DIFF
--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,0 +1,234 @@
+# Simple-SDS serialization format
+
+Version 5. Updated 2021-05-08.
+
+## Basics
+
+This document specifies the portable simple-sds serialization format for the GBWT.
+It is an alternative to the old file format based on SDSL data structures.
+The format builds upon the basic data structures described in: [https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md](https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md).
+
+### String array
+
+A **string array** stores multiple concatenated strings in a single array.
+It reduces the overhead from memory allocations and enables fast serialization and loading.
+
+Serialization format for string arrays:
+
+1. `index`: Starting offset of each string as a sparse vector.
+2. `alphabet`: Alphabet as a vector of bytes.
+3. `strings`: Concatenated strings as an integer vector.
+
+The serialization format uses alphabet compaction.
+`alphabet` and `strings` can be decompressed into a vector of bytes as `bytes[i] = alphabet[strings[i]]`.
+The sequence of bytes from `bytes[index.select(i)]` (inclusive) to `bytes[index.select(i + 1)]` (exclusive) encodes the `i`th string using UTF-8.
+
+### Dictionary
+
+A **dictionary** stores a mapping between `n` distinct strings and a semiopen interval of integers `0..n`.
+
+Serialization format for dictionaries:
+
+1. `strings`: Concatenated strings as a string array.
+2. `sorted_ids`: Permutation of `0..n` as an integer vector.
+
+Permutation `sorted_ids` stores the identifiers of the strings in lexicographic order.
+Strings can be mapped to their identifiers using binary search in the permutation.
+
+### Byte code
+
+Some structures encode integers using a variable-length **byte code**.
+The 7 low-order bits of each byte contain data, while the high-order bit is set if and only if the encoding continues in the next byte.
+The encoding is little-endian.
+The first byte stores bits 0 to 6 of the integer, the second byte stores bits 7 to 13, and so on.
+
+### Run-length encoding
+
+**Run-length encoding**, as used in the GBWT, encodes a run of `length > 0` equal integers `value` as a sequence of bytes.
+The encoding depends on the size of the **local alphabet** `sigma`.
+This assumes that the local alphabet consists of integers in the semiopen interval `0..sigma`.
+Let `run_continues = floor(256 / sigma)` be a boundary value.
+
+If `run_continues > 0`, we encode short runs as a single byte.
+If `length < run_continues`, the run is encoded as byte `value + sigma * (length - 1)`.
+Otherwise the first byte stores `value + sigma * (run_continues - 1)`.
+Subsequent bytes encode the remaining run length `length - run_continues` using byte code.
+If `run_continues == 0`, we first encode `value` and then `length - 1` using byte code.
+
+## GBWT
+
+The **GBWT** is a run-length encoded FM-index storing integer sequences.
+The integers are interpreted as node identifiers and the sequences as paths in a graph.
+Each path starts from a special **endmarker** node 0, which does not exist in the graph.
+There must be at least one real node in addition to the endmarker on each path.
+
+Serialization format for the GBWT:
+
+1. GBWT header
+2. Tags
+3. BWT
+4. Optional document array samples
+5. Optional metadata
+
+A GBWT index may be **bidirectional**.
+In a bidirectional index, the forward strand of **original node** `v` is mapped to **GBWT node** `2 * v` and the reverse strand to `2 * v + 1`.
+The reverse strand of the endmarker node is never used.
+A bidirectional index also stores each **original path** as two **GBWT paths**.
+The forward sequence for original path `i` is stored as GBWT path `2 * i`.
+The reverse sequence, which visits the opposite strands of each node in reverse order, is stored as GBWT path `2 * i + 1`.
+
+### GBWT header
+
+**GBWT header** is a 48-byte (6-element) structure with the following fields:
+
+1. `tag`: Value `0x6B376B37` as a 32-bit integer.
+2. `version`: File format version as a 32-bit integer.
+3. `sequences`: Number of integer sequences / GBWT paths stored in the BWT as an element.
+4. `size`: Total length of the integer sequences (including the endmarkers) as an element.
+5. `offset`: Alphabet offset as an element.
+6. `alphabet_size`: Size of the alphabet as an element.
+7. `flags`: Binary flags as an element.
+
+The first two fields are 32-bit unsigned little-endian integers for compatibility with the SDSL-based serialization format.
+Simple-SDS serialization format requires file format version `5`.
+
+Because the BWT stores some information for all integers in the **effective alphabet**, the GBWT uses simple alphabet compaction based on an alphabet offset:
+
+* Node identifier `0` becomes `0` in the effective alphabet.
+* Node identifiers in the closed range from `1` to `offset` are not used.
+* Node identifiers `i` in the closed range from `offset + 1` to `alphabet_size - 1` become `i - offset` in the effective alphabet.
+
+In a bidirectional GBWT, value `1` in the effective alphabet typically corresponds to the forward strand of the original node with the smallest identifier.
+
+The following flags are supported:
+
+* `0x0001`: The GBWT is bidirectional.
+* `0x0002`: The metadata structure is present.
+* `0x0004`: Simple-SDS format.
+
+Other flag bits must not be set.
+The metadata flag must be set if and only if the metadata structure is present.
+If the simple-sds bit is not set, the serialized data is in the SDSL format.
+
+### Tags
+
+**Tags** are key-value pairs that can be used for arbitrary annotations.
+Both keys and values are strings.
+
+Serialization format for tags:
+
+1. Keys and values as a string array.
+
+Keys are case-insensitive, and they must be distinct.
+The key of tag `i` is string `2 * i` and the value is string `2 * i + 1`.
+
+If key `source` is present, the corresponding value indicates the GBWT implementation used for serializing the structure.
+The reader may use that information for determining if it can understand the serialization formats for unspecified optional structures.
+The original GBWT implementation is `jltsiren/gbwt`.
+
+### BWT
+
+The **BWT** stores graph topology and the paths.
+It is divided into records that correspond to GBWT nodes.
+
+Serialization format for the BWT:
+
+1. `index`: Starting offset of each record as a sparse vector.
+2. `data`: Encoded records as a vector of bytes.
+
+Let `v` be a GBWT node and `i` the corresponding value in the effective alphabet.
+The corresponding record is encoded as the sequence of bytes from `data[index.select(i)]` (inclusive) to `data[index.select(i + 1)]` (exclusive).
+Local alphabet size `sigma` is the number of outgoing edges from node `v`.
+If the GBWT is bidirectional and original graph is a bidirected sequence graph, `sigma` is the number of edges adjacent to the exit side of the node traversal corresponding to `v`.
+Edges not used on the indexed paths may be omitted from the local alphabet.
+If such edges are omitted from all records, the BWT encodes the topology of the subgraph induced by the paths.
+
+### BWT records
+
+The **record**  for GBWT node `v` starts with a header that encodes graph topology.
+It starts with the byte code encoding of local alphabet size `sigma`.
+Then, for each outgoing edge `(v, w)` in ascending order by `w`, we store a pair of byte code encoded values.
+If a path ends at node `v`, the first edge is always `(v, 0)` to the endmarker.
+The first value is `w - prev`, where `prev` is either the destination node of the previous edge or `0` for the first edge.
+The second value is `rank(v, w)`, or the number of occurrences of `w` in the BWT before node `v`.
+This can be understood as the total number of times an edge `(u, w)` is used on the indexed paths, for all `u < v`.
+
+The header is followed by the body of the record.
+Each offset `BWT(v)[j]` in the body corresponds to a visit by a path to node `v`.
+The visits are sorted by the previous node `u` on the path, with ties broken by the order in node `u`.
+`BWT(v)[j]` stores the next node `w` visited by the path, or the endmarker `0` if the path ends.
+We encode the body by replacing each node `w` with the index of the corresponding edge in the header and by run-length encoding the result.
+A path that visits offset `j` of node `v` continues to offset `rank(v, w) + BWT(v).rank(j, w)` of node `w = BWT(v)[j]`.
+
+**Note:** The GBWT path with identifier `j` starts at offset `j` of the endmarker `0`.
+
+**Note:** In a bidirectional GBWT, run-length encoding does not compress the body of the endmarker well.
+Implementations may want to decompress the endmarker into the array of starting positions of each path.
+
+**Note:** The GBWT is a multi-string BWT.
+Each occurrence of the endmarker marking the end of a path in the GBWT has a distinct implicit character value.
+Hence we cannot jump from the end of a path to its start based on the information stored in the BWT.
+
+### Document array samples
+
+**Document array samples** can be used for converting BWT positions to GBWT path identifiers and for jumping to a specified offset in a specified sequence.
+These structures are often compilicated and both implementation-dependent and application-dependent.
+Hence they are optional and not part of this specification.
+
+## Metadata
+
+**Metadata** stores statistics about the paths and structured names for each original path.
+
+Serialization format for metadata:
+
+1. Metadata header.
+2. Vector of path names.
+3. Sample names as a dictionary.
+4. Contig names as a dictionary.
+
+The number of path names must be either `0` or equal to the number of original paths in the GBWT index.
+The number of sample/contig names must be either `0` or equal to the sample / contig count in the header.
+
+### Metadata header
+
+**Metadata header** is a 40-byte (5-element) structure with the following fields:
+
+1. `tag`: Value `0x6B375E7A` as a 32-bit integer.
+2. `version`: File format version as a 32-bit integer.
+3. `sample_count`: Number of samples as an element.
+4. `haplotype_count`: Number of haplotypes as an element.
+5. `contig_count`: Number of contigs as an element.
+6. `flags`: Binary flags as an element.
+
+The first two fields are 32-bit unsigned little-endian integers for compatibility with the SDSL-based serialization format.
+Simple-SDS serialization format requires file format version `2`.
+Contigs typically match connected components in the graph.
+Haplotype count is an estimate for the total number of full-length paths in each component.
+
+The following flags are supported:
+
+* `0x0001`: Metadata contains path names.
+* `0x0002`: Metadata contains sample names.
+* `0x0004`: Metadata contains contig names.
+
+Other flag bits must not be set.
+A name flag must be set if and only if the corresponding names are present in the structure.
+
+### Path names
+
+**Path name** is a 16-byte (2-element) structure with the following fields:
+
+1. `sample`: Sample identifier as a 32-bit integer.
+2. `contig`: Contig identifier as a 32-bit integer.
+3. `phase`: Phase / haplotype identifier as a 32-bit integer.
+4. `fragment`: Fragment index as a 32-bit integer.
+
+The fields use 32-bit unsigned little-endian integers to save space.
+Each path name must be unique.
+Sample / contig identifiers must be in the semiopen interval `0..sample_count` / `0..contig_count`.
+If sample / contig names are present, the corresponding dictionaries can be used for mapping between identifiers and names.
+
+The `fragment` field can be used for several purposes, including:
+
+* Fragment index for path fragments from the same sample, contig, and phase.
+* Starting offset of the fragment in the corresponding sequence.

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -141,11 +141,7 @@ main(int argc, char** argv)
   std::cout << std::endl;
 
   GBWT compressed_index;
-  if(!sdsl::load_from_file(compressed_index, index_base + GBWT::EXTENSION))
-  {
-    std::cerr << "benchmark: Cannot load the index from " << (index_base + GBWT::EXTENSION) << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
+  sdsl::simple_sds::load_from(compressed_index, index_base + GBWT::EXTENSION);
   printStatistics(compressed_index, index_base);
 
   if(breakdown)
@@ -166,11 +162,7 @@ main(int argc, char** argv)
   if(compare)
   {
     GBWT second_index;
-    if(!sdsl::load_from_file(second_index, compare_base + GBWT::EXTENSION))
-    {
-      std::cerr << "benchmark: Cannot load the index from " << (compare_base + GBWT::EXTENSION) << std::endl;
-      std::exit(EXIT_FAILURE);
-    }
+    sdsl::simple_sds::load_from(second_index, compare_base + GBWT::EXTENSION);
     printStatistics(second_index, compare_base);
     compareIndexes(compressed_index, second_index, index_base, compare_base);
   }

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -23,7 +23,6 @@
 */
 
 #include <fstream>
-#include <map>
 #include <random>
 #include <string>
 #include <unistd.h>

--- a/build_gbwt.cpp
+++ b/build_gbwt.cpp
@@ -120,7 +120,7 @@ main(int argc, char** argv)
   if(input_files.empty() || output_base.empty()) { printUsage(EXIT_FAILURE); }
   if(resample && input_files.size() != 1)
   {
-    std::cerr << "build_gbwt: Resampling only works with a single index" << std::endl;
+    std::cerr << "build_gbwt: Resampling requires a single input" << std::endl;
     std::exit(EXIT_FAILURE);
   }
   if(verify_index && !(input_files.size() == 1 && index_base.empty() && !build_from_parse))
@@ -335,7 +335,7 @@ main(int argc, char** argv)
     std::cout << std::endl;
 
     GBWT compressed_index;
-    sdsl::simple_sds::load_from(compressed_index, gbwt_name);
+    sdsl::simple_sds::load_from(compressed_index, input_base + GBWT::EXTENSION);
     compressed_index.resample(sample_interval);
     printStatistics(compressed_index, output_base);
 

--- a/build_ri.cpp
+++ b/build_ri.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2018, 2020 Jouni Siren
+  Copyright (c) 2018, 2020, 2021 Jouni Siren
   Copyright (c) 2017 Genome Research Ltd.
 
   Author: Jouni Siren <jouni.siren@iki.fi>
@@ -83,11 +83,7 @@ main(int argc, char** argv)
 
   std::string gbwt_name = base_name + GBWT::EXTENSION;
   GBWT gbwt_index;
-  if(!sdsl::load_from_file(gbwt_index, gbwt_name))
-  {
-    std::cerr << "build_ri: Cannot load the GBWT index from " << gbwt_name << std::endl;
-    std::exit(EXIT_FAILURE);
-  }
+  sdsl::simple_sds::load_from(gbwt_index, gbwt_name);
   printStatistics(gbwt_index, base_name);
 
   FastLocate r_index(gbwt_index);

--- a/dynamic_gbwt.cpp
+++ b/dynamic_gbwt.cpp
@@ -26,8 +26,6 @@
 #include <gbwt/dynamic_gbwt.h>
 #include <gbwt/bwtmerge.h>
 
-#include <sdsl/simple_sds.hpp>
-
 #include <memory>
 #include <unordered_map>
 

--- a/dynamic_gbwt.cpp
+++ b/dynamic_gbwt.cpp
@@ -26,6 +26,8 @@
 #include <gbwt/dynamic_gbwt.h>
 #include <gbwt/bwtmerge.h>
 
+#include <sdsl/simple_sds.hpp>
+
 #include <memory>
 #include <unordered_map>
 
@@ -144,7 +146,7 @@ DynamicGBWT::load(std::istream& in)
   this->header.load(in);
   if(!(this->header.check()))
   {
-    std::cerr << "DynamicGBWT::load(): Invalid header: " << this->header << std::endl;
+    throw sdsl::simple_sds::InvalidData("DynamicGBWT: Invalid header");
   }
   this->header.setVersion();  // Update to the current version.
   this->bwt.resize(this->effective());

--- a/fast_locate.cpp
+++ b/fast_locate.cpp
@@ -25,8 +25,6 @@
 #include <gbwt/fast_locate.h>
 #include <gbwt/internal.h>
 
-#include <sdsl/simple_sds.hpp>
-
 namespace gbwt
 {
 

--- a/fast_locate.cpp
+++ b/fast_locate.cpp
@@ -25,6 +25,8 @@
 #include <gbwt/fast_locate.h>
 #include <gbwt/internal.h>
 
+#include <sdsl/simple_sds.hpp>
+
 namespace gbwt
 {
 
@@ -159,9 +161,7 @@ FastLocate::load(std::istream& in)
   this->header.load(in);
   if(!(this->header.check()))
   {
-    std::cerr << "FastLocate::load(): Invalid or old header" << std::endl;
-    std::cerr << "FastLocate::load(): Header version is " << this->header.version << "; expected " << Header::VERSION << std::endl;
-    return;
+    throw sdsl::simple_sds::InvalidData("FastLocate: Invalid header");
   }
   this->header.setVersion(); // Update to the current version.
 

--- a/files.cpp
+++ b/files.cpp
@@ -208,6 +208,19 @@ MetadataHeader::check() const
   }
 }
 
+bool
+MetadataHeader::check_simple_sds() const
+{
+  if(this->tag != TAG) { return false; }
+  switch(this->version)
+  {
+  case VERSION:
+    return ((this->flags & FLAG_MASK) == this->flags);
+  default:
+    return false;
+  }
+}
+
 void
 MetadataHeader::swap(MetadataHeader& another)
 {

--- a/files.cpp
+++ b/files.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2017, 2018, 2019 Jouni Sirén
+  Copyright (c) 2017, 2018, 2019, 2021 Jouni Sirén
   Copyright (c) 2015, 2016, 2017 Genome Research Ltd.
 
   Author: Jouni Siren <jouni.siren@iki.fi>
@@ -37,6 +37,10 @@ constexpr std::uint32_t GBWTHeader::VERSION;
 constexpr std::uint64_t GBWTHeader::FLAG_MASK;
 constexpr std::uint64_t GBWTHeader::FLAG_BIDIRECTIONAL;
 constexpr std::uint64_t GBWTHeader::FLAG_METADATA;
+constexpr std::uint64_t GBWTHeader::FLAG_SIMPLE_SDS;
+
+constexpr std::uint32_t GBWTHeader::META2_VERSION;
+constexpr std::uint64_t GBWTHeader::META2_FLAG_MASK;
 constexpr std::uint32_t GBWTHeader::META_VERSION;
 constexpr std::uint64_t GBWTHeader::META_FLAG_MASK;
 constexpr std::uint32_t GBWTHeader::BD_VERSION;
@@ -93,6 +97,8 @@ GBWTHeader::check() const
   {
   case VERSION:
     return ((this->flags & FLAG_MASK) == this->flags);
+  case META2_VERSION:
+    return ((this->flags & META2_FLAG_MASK) == this->flags);
   case META_VERSION:
     return ((this->flags & META_FLAG_MASK) == this->flags);
   case BD_VERSION:

--- a/gbwt.cpp
+++ b/gbwt.cpp
@@ -122,6 +122,14 @@ GBWT::operator=(GBWT&& source)
   return *this;
 }
 
+void
+GBWT::resample(size_type sample_interval)
+{
+  this->da_samples = DASamples(); // Delete samples to save memory.
+  std::vector<std::pair<node_type, sample_type>> samples = gbwt::resample(*this, sample_interval);
+  this->da_samples = DASamples(this->bwt, samples);
+}
+
 size_type
 GBWT::serialize(std::ostream& out, sdsl::structure_tree_node* v, std::string name) const
 {

--- a/gbwt.cpp
+++ b/gbwt.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2017, 2019, 2020 Jouni Siren
+  Copyright (c) 2017, 2019, 2020, 2021 Jouni Siren
   Copyright (c) 2017 Genome Research Ltd.
 
   Author: Jouni Siren <jouni.siren@iki.fi>
@@ -27,8 +27,6 @@
 
 #include <gbwt/dynamic_gbwt.h>
 #include <gbwt/internal.h>
-
-#include <sdsl/simple_sds.hpp>
 
 namespace gbwt
 {

--- a/gbwt.cpp
+++ b/gbwt.cpp
@@ -28,6 +28,8 @@
 #include <gbwt/dynamic_gbwt.h>
 #include <gbwt/internal.h>
 
+#include <sdsl/simple_sds.hpp>
+
 namespace gbwt
 {
 
@@ -140,7 +142,7 @@ GBWT::load(std::istream& in)
   this->header.load(in);
   if(!(this->header.check()))
   {
-    std::cerr << "GBWT::load(): Invalid header: " << this->header << std::endl;
+    throw sdsl::simple_sds::InvalidData("GBWT: Invalid header");
   }
   this->header.setVersion();  // Update to the current version.
 

--- a/include/gbwt/algorithms.h
+++ b/include/gbwt/algorithms.h
@@ -26,8 +26,6 @@
 #ifndef GBWT_ALGORITHMS_H
 #define GBWT_ALGORITHMS_H
 
-#include <map>
-
 #include <gbwt/support.h>
 
 namespace gbwt

--- a/include/gbwt/algorithms.h
+++ b/include/gbwt/algorithms.h
@@ -264,6 +264,49 @@ extract(const GBWTType& index, size_type sequence)
 
 //------------------------------------------------------------------------------
 
+/*
+  Returns DA samples for the given sample interval in sorted order.
+
+  Template parameters:
+    GBWTType  GBWT or DynamicGBWT
+*/
+
+template<class GBWTType>
+std::vector<std::pair<comp_type, sample_type>>
+resample(const GBWTType& index, size_type sample_interval)
+{
+  if(sample_interval == 0) { sample_interval = std::numeric_limits<size_type>::max(); }
+  std::vector<std::pair<comp_type, sample_type>> result;
+
+  #pragma omp parallel for schedule(dynamic, 1)
+  for(size_type sequence = 0; sequence < index.sequences(); sequence++)
+  {
+    std::vector<edge_type> buffer;
+    edge_type curr(ENDMARKER, sequence);
+    size_type distance = 0; // From the initial endmarker to the next position.
+    do
+    {
+      edge_type next = index.LF(curr); distance++;
+      if(distance % sample_interval == 0 || next.first == ENDMARKER) { buffer.push_back(curr); }
+      curr = next;
+    }
+    while(curr.first != ENDMARKER);
+    #pragma omp critical
+    {
+      result.reserve(result.size() + buffer.size());
+      for(edge_type pos : buffer)
+      {
+        result.emplace_back(index.toComp(pos.first), sample_type(pos.second, sequence));
+      }
+    }
+  }
+
+  parallelQuickSort(result.begin(), result.end());
+  return result;
+}
+
+//------------------------------------------------------------------------------
+
 } // namespace gbwt
 
 #endif // GBWT_ALGORITHMS_H

--- a/include/gbwt/dynamic_gbwt.h
+++ b/include/gbwt/dynamic_gbwt.h
@@ -65,6 +65,8 @@ public:
   DynamicGBWT& operator=(const GBWT& source);
   DynamicGBWT& operator=(DynamicGBWT&& source);
 
+  void resample(size_type sample_interval);
+
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
 

--- a/include/gbwt/dynamic_gbwt.h
+++ b/include/gbwt/dynamic_gbwt.h
@@ -68,6 +68,10 @@ public:
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
 
+  void simple_sds_serialize(std::ostream& out) const;
+  void simple_sds_load(std::istream& in);
+  size_t simple_sds_size() const;
+
   const static std::string EXTENSION; // .gbwt
 
 //------------------------------------------------------------------------------

--- a/include/gbwt/dynamic_gbwt.h
+++ b/include/gbwt/dynamic_gbwt.h
@@ -317,9 +317,10 @@ public:
 
 //------------------------------------------------------------------------------
 
-  GBWTHeader                 header;
-  std::vector<DynamicRecord> bwt;
-  Metadata                   metadata;
+  GBWTHeader                         header;
+  std::map<std::string, std::string> tags;
+  std::vector<DynamicRecord>         bwt;
+  Metadata                           metadata;
 
 //------------------------------------------------------------------------------
 
@@ -330,6 +331,8 @@ public:
 private:
   void copy(const DynamicGBWT& source);
   void copy(const GBWT& source);
+  void resetTags();
+  void addSource();
 
   // Change offset and alphabet size.
   void forceResize(size_type new_offset, size_type new_sigma);

--- a/include/gbwt/files.h
+++ b/include/gbwt/files.h
@@ -82,7 +82,7 @@ struct GBWTHeader
   constexpr static std::uint64_t FLAG_MASK          = 0x0007;
   constexpr static std::uint64_t FLAG_BIDIRECTIONAL = 0x0001; // The index is bidirectional.
   constexpr static std::uint64_t FLAG_METADATA      = 0x0002; // The index contains metadata.
-  constexpr static std::uint64_t FLAG_SIMPLE_SDS    = 0x0004; // Simple-SDS file format.
+  constexpr static std::uint64_t FLAG_SIMPLE_SDS    = 0x0004; // simple-sds file format.
 
   // Flag masks for old compatible versions.
   constexpr static std::uint32_t META2_VERSION      = 4;
@@ -99,6 +99,7 @@ struct GBWTHeader
 
   GBWTHeader();
 
+  // simple-sds serialization sees the header as a serializable value.
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
   bool check() const;
@@ -161,11 +162,10 @@ struct MetadataHeader
 
   MetadataHeader();
 
+  // simple-sds serialization sees the header as a serializable value.
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
   bool check() const;
-
-  // Simple-SDS serialization sees the header as a serializable value.
   bool check_simple_sds() const;
 
   void setVersion() { this->version = VERSION; }

--- a/include/gbwt/files.h
+++ b/include/gbwt/files.h
@@ -32,7 +32,7 @@ namespace gbwt
 {
 
 /*
-  files.h: Public interface for file formats.
+  files.h: File format headers.
 */
 
 //------------------------------------------------------------------------------
@@ -116,6 +116,66 @@ struct GBWTHeader
 };
 
 std::ostream& operator<<(std::ostream& stream, const GBWTHeader& header);
+
+//------------------------------------------------------------------------------
+
+/*
+  Metadata structure header.
+
+  Version 2:
+  - Work in progress.
+  - Compatible with versions 0 to 1.
+
+  Version 1:
+  - Sample names, contig names, path names.
+  - Compatible with version 0.
+
+  Version 0:
+  - Preliminary version with sample/haplotype/contig counts.
+*/
+
+struct MetadataHeader
+{
+  typedef gbwt::size_type size_type; // Needed for SDSL serialization.
+
+  std::uint32_t tag;
+  std::uint32_t version;
+  std::uint64_t sample_count;
+  std::uint64_t haplotype_count;
+  std::uint64_t contig_count;
+  std::uint64_t flags;
+
+  constexpr static std::uint32_t TAG = 0x6B375E7A;
+  constexpr static std::uint32_t VERSION = Version::METADATA_VERSION;
+
+  constexpr static std::uint64_t FLAG_MASK         = 0x0007;
+  constexpr static std::uint64_t FLAG_PATH_NAMES   = 0x0001;
+  constexpr static std::uint64_t FLAG_SAMPLE_NAMES = 0x0002;
+  constexpr static std::uint64_t FLAG_CONTIG_NAMES = 0x0004;
+
+  // Flag masks for old compatible versions.
+  constexpr static std::uint32_t NAMES_VERSION     = 1;
+  constexpr static std::uint64_t NAMES_FLAG_MASK   = 0x0007;
+  constexpr static std::uint32_t INITIAL_VERSION   = 0;
+  constexpr static std::uint64_t INITIAL_FLAG_MASK = 0x0000;
+
+  MetadataHeader();
+
+  size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
+  void load(std::istream& in);
+  bool check() const;
+
+  void setVersion() { this->version = VERSION; }
+
+  void set(std::uint64_t flag) { this->flags |= flag; }
+  void unset(std::uint64_t flag) { this->flags &= ~flag; }
+  bool get(std::uint64_t flag) const { return (this->flags & flag); }
+
+  void swap(MetadataHeader& another);
+
+  bool operator==(const MetadataHeader& another) const;
+  bool operator!=(const MetadataHeader& another) const { return !(this->operator==(another)); }
+};
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwt/files.h
+++ b/include/gbwt/files.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2017, 2018, 2019 Jouni Siren
+  Copyright (c) 2017, 2018, 2019, 2021 Jouni Siren
   Copyright (c) 2015, 2016, 2017 Genome Research Ltd.
 
   Author: Jouni Siren <jouni.siren@iki.fi>
@@ -40,6 +40,10 @@ namespace gbwt
 /*
   GBWT file header.
 
+  Version 5:
+  - Work in progress.
+  - Compatible with versions 1 to 4.
+
   Version 4:
   - Uses metadata version 1.
   - Compatible with versions 1 to 3.
@@ -75,11 +79,15 @@ struct GBWTHeader
   constexpr static std::uint32_t TAG = 0x6B376B37;
   constexpr static std::uint32_t VERSION = Version::GBWT_VERSION;
 
-  constexpr static std::uint64_t FLAG_MASK          = 0x0003;
+  constexpr static std::uint64_t FLAG_MASK          = 0x0007;
   constexpr static std::uint64_t FLAG_BIDIRECTIONAL = 0x0001; // The index is bidirectional.
   constexpr static std::uint64_t FLAG_METADATA      = 0x0002; // The index contains metadata.
+  constexpr static std::uint64_t FLAG_SIMPLE_SDS    = 0x0004; // Simple-SDS file format. (FIXME not in use yet)
 
   // Flag masks for old compatible versions.
+  constexpr static std::uint32_t META2_VERSION      = 4;
+  constexpr static std::uint64_t META2_FLAG_MASK    = 0x0003;
+
   constexpr static std::uint32_t META_VERSION       = 3;
   constexpr static std::uint64_t META_FLAG_MASK     = 0x0003;
 

--- a/include/gbwt/files.h
+++ b/include/gbwt/files.h
@@ -82,7 +82,7 @@ struct GBWTHeader
   constexpr static std::uint64_t FLAG_MASK          = 0x0007;
   constexpr static std::uint64_t FLAG_BIDIRECTIONAL = 0x0001; // The index is bidirectional.
   constexpr static std::uint64_t FLAG_METADATA      = 0x0002; // The index contains metadata.
-  constexpr static std::uint64_t FLAG_SIMPLE_SDS    = 0x0004; // Simple-SDS file format. (FIXME not in use yet)
+  constexpr static std::uint64_t FLAG_SIMPLE_SDS    = 0x0004; // Simple-SDS file format.
 
   // Flag masks for old compatible versions.
   constexpr static std::uint32_t META2_VERSION      = 4;

--- a/include/gbwt/files.h
+++ b/include/gbwt/files.h
@@ -41,7 +41,9 @@ namespace gbwt
   GBWT file header.
 
   Version 5:
-  - Work in progress.
+  - Uses metadata version 2.
+  - Includes tags.
+  - SDSL and simple-sds formats.
   - Compatible with versions 1 to 4.
 
   Version 4:

--- a/include/gbwt/files.h
+++ b/include/gbwt/files.h
@@ -123,7 +123,7 @@ std::ostream& operator<<(std::ostream& stream, const GBWTHeader& header);
   Metadata structure header.
 
   Version 2:
-  - Work in progress.
+  - Uses Dictionary based on StringArray.
   - Compatible with versions 0 to 1.
 
   Version 1:
@@ -164,6 +164,9 @@ struct MetadataHeader
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
   bool check() const;
+
+  // Simple-SDS serialization sees the header as a serializable value.
+  bool check_simple_sds() const;
 
   void setVersion() { this->version = VERSION; }
 

--- a/include/gbwt/gbwt.h
+++ b/include/gbwt/gbwt.h
@@ -266,10 +266,11 @@ public:
 
 //------------------------------------------------------------------------------
 
-  GBWTHeader  header;
-  RecordArray bwt;
-  DASamples   da_samples;
-  Metadata    metadata;
+  GBWTHeader                         header;
+  std::map<std::string, std::string> tags;
+  RecordArray                        bwt;
+  DASamples                          da_samples;
+  Metadata                           metadata;
 
   // Decompress and cache the endmarker, because decompressing it is expensive.
   DecompressedRecord endmarker_record;
@@ -282,6 +283,8 @@ public:
 
 private:
   void copy(const GBWT& source);
+  void resetTags();
+  void addSource();
   void cacheEndmarker();
 
 public:

--- a/include/gbwt/gbwt.h
+++ b/include/gbwt/gbwt.h
@@ -67,6 +67,10 @@ public:
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
 
+  void simple_sds_serialize(std::ostream& out) const;
+  void simple_sds_load(std::istream& in);
+  size_t simple_sds_size() const;
+
   const static std::string EXTENSION; // .gbwt
 
 //------------------------------------------------------------------------------

--- a/include/gbwt/gbwt.h
+++ b/include/gbwt/gbwt.h
@@ -64,6 +64,8 @@ public:
   GBWT& operator=(const DynamicGBWT& source);
   GBWT& operator=(GBWT&& source);
 
+  void resample(size_type sample_interval);
+
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
 
@@ -188,7 +190,7 @@ public:
   comp_type toComp(node_type node) const { return (node == 0 ? node : node - this->header.offset); }
   node_type toNode(comp_type comp) const { return (comp == 0 ? comp : comp + this->header.offset); }
 
-  size_type nodeSize(node_type node) const { return this->record(node).size(); }
+  size_type nodeSize(node_type node) const { return this->bwt.size(this->toComp(node)); }
   bool empty(node_type node) const { return this->bwt.empty(this->toComp(node)); }
 
 //------------------------------------------------------------------------------

--- a/include/gbwt/internal.h
+++ b/include/gbwt/internal.h
@@ -102,10 +102,6 @@ serializeVector(const std::vector<Element>& data, std::ostream& out, sdsl::struc
   return written_bytes;
 }
 
-// Specialization for a vector of strings.
-template<>
-size_type serializeVector<std::string>(const std::vector<std::string>& data, std::ostream& out, sdsl::structure_tree_node* v, std::string name);
-
 // Load an std::vector of integers.
 template<class Element>
 void
@@ -120,10 +116,6 @@ loadVector(std::vector<Element>& data, std::istream& in)
     DiskIO::read(in, data.data(), data_size);
   }
 }
-
-// Specialization for a vector of strings.
-template<>
-void loadVector<std::string>(std::vector<std::string>& data, std::istream& in);
 
 //------------------------------------------------------------------------------
 

--- a/include/gbwt/metadata.h
+++ b/include/gbwt/metadata.h
@@ -25,6 +25,7 @@
 #ifndef GBWT_METADATA_H
 #define GBWT_METADATA_H
 
+#include <gbwt/files.h>
 #include <gbwt/support.h>
 
 namespace gbwt
@@ -67,67 +68,24 @@ struct PathName
 
 //------------------------------------------------------------------------------
 
-/*
-  Version 2:
-  - Work in progress.
-  - Compatible with versions 0 to 1.
-
-  Version 1:
-  - Sample names, contig names, path names.
-  - Compatible with version 0.
-
-  Version 0:
-  - Preliminary version with sample/haplotype/contig counts.
-
-  Future versions:
-  - Haplotype coverage over ranges of node ids (run-length encode with sd_vector).
-  - Assign contig ids to ranges of node ids (as above).
-*/
-
 class Metadata
 {
 public:
   typedef gbwt::size_type size_type; // Needed for SDSL serialization.
 
   // Header.
-  std::uint32_t tag;
-  std::uint32_t version;
-  std::uint64_t sample_count;
-  std::uint64_t haplotype_count;
-  std::uint64_t contig_count;
-  std::uint64_t flags;
+  MetadataHeader        header;
 
   // Path / sample / contig names.
   std::vector<PathName> path_names;
   Dictionary            sample_names;
   Dictionary            contig_names;
 
-  constexpr static std::uint32_t TAG = 0x6B375E7A;
-  constexpr static std::uint32_t VERSION = Version::METADATA_VERSION;
-
-  constexpr static std::uint64_t FLAG_MASK         = 0x0007;
-  constexpr static std::uint64_t FLAG_PATH_NAMES   = 0x0001;
-  constexpr static std::uint64_t FLAG_SAMPLE_NAMES = 0x0002;
-  constexpr static std::uint64_t FLAG_CONTIG_NAMES = 0x0004;
-
-  // Flag masks for old compatible versions.
-  constexpr static std::uint32_t NAMES_VERSION     = 1;
-  constexpr static std::uint64_t NAMES_FLAG_MASK   = 0x0007;
-  constexpr static std::uint32_t INITIAL_VERSION   = 0;
-  constexpr static std::uint64_t INITIAL_FLAG_MASK = 0x0000;
-
   Metadata();
   Metadata(std::vector<const Metadata*> sources, bool same_samples, bool same_contigs);
 
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
-  bool check() const;
-
-  void setVersion() { this->version = VERSION; }
-
-  void set(std::uint64_t flag) { this->flags |= flag; }
-  void unset(std::uint64_t flag) { this->flags &= ~flag; }
-  bool get(std::uint64_t flag) const { return (this->flags & flag); }
 
   void swap(Metadata& another);
 
@@ -135,15 +93,15 @@ public:
   bool operator!=(const Metadata& another) const { return !(this->operator==(another)); }
 
   // Header operations.
-  size_type samples() const { return this->sample_count; }
-  size_type haplotypes() const { return this->haplotype_count; }
-  size_type contigs() const { return this->contig_count; }
+  size_type samples() const { return this->header.sample_count; }
+  size_type haplotypes() const { return this->header.haplotype_count; }
+  size_type contigs() const { return this->header.contig_count; }
   void setSamples(size_type n);
   void setHaplotypes(size_type n);
   void setContigs(size_type n);
 
   // Path operations.
-  bool hasPathNames() const { return this->get(FLAG_PATH_NAMES); }
+  bool hasPathNames() const { return this->header.get(MetadataHeader::FLAG_PATH_NAMES); }
   size_type paths() const { return this->path_names.size(); }
   const PathName& path(size_type i) const { return this->path_names[i]; }
   std::vector<size_type> findPaths(size_type sample_id, size_type contig_id) const;
@@ -154,7 +112,7 @@ public:
   void clearPathNames();
 
   // Sample operations.
-  bool hasSampleNames() const { return this->get(FLAG_SAMPLE_NAMES); }
+  bool hasSampleNames() const { return this->header.get(MetadataHeader::FLAG_SAMPLE_NAMES); }
   std::string sample(size_type i) const { return this->sample_names[i]; }
   size_type sample(const std::string& name) const { return this->sample_names.find(name); }
   void setSamples(const std::vector<std::string>& names);
@@ -162,7 +120,7 @@ public:
   void clearSampleNames();
 
   // Contig operations.
-  bool hasContigNames() const { return this->get(FLAG_CONTIG_NAMES); }
+  bool hasContigNames() const { return this->header.get(MetadataHeader::FLAG_CONTIG_NAMES); }
   std::string contig(size_type i) const { return this->contig_names[i]; }
   size_type contig(const std::string& name) const { return this->contig_names.find(name); }
   void setContigs(const std::vector<std::string>& names);

--- a/include/gbwt/metadata.h
+++ b/include/gbwt/metadata.h
@@ -145,6 +145,10 @@ public:
   void merge(const Metadata& source, bool same_samples, bool same_contigs);
 
   void clear();
+
+private:
+  // Throws `sdsl::simple_sds::InvalidData` if the checks fail.
+  void sanityChecks() const;
 };
 
 std::ostream& operator<<(std::ostream& stream, const Metadata& metadata);

--- a/include/gbwt/metadata.h
+++ b/include/gbwt/metadata.h
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019, 2020 Jouni Siren
+  Copyright (c) 2019, 2020, 2021 Jouni Siren
 
   Author: Jouni Siren <jouni.siren@iki.fi>
 
@@ -68,6 +68,10 @@ struct PathName
 //------------------------------------------------------------------------------
 
 /*
+  Version 2:
+  - Work in progress.
+  - Compatible with versions 0 to 1.
+
   Version 1:
   - Sample names, contig names, path names.
   - Compatible with version 0.
@@ -107,6 +111,8 @@ public:
   constexpr static std::uint64_t FLAG_CONTIG_NAMES = 0x0004;
 
   // Flag masks for old compatible versions.
+  constexpr static std::uint32_t NAMES_VERSION     = 1;
+  constexpr static std::uint64_t NAMES_FLAG_MASK   = 0x0007;
   constexpr static std::uint32_t INITIAL_VERSION   = 0;
   constexpr static std::uint64_t INITIAL_FLAG_MASK = 0x0000;
 

--- a/include/gbwt/metadata.h
+++ b/include/gbwt/metadata.h
@@ -87,6 +87,10 @@ public:
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
 
+  void simple_sds_serialize(std::ostream& out) const;
+  void simple_sds_load(std::istream& in);
+  size_t simple_sds_size() const;
+
   void swap(Metadata& another);
 
   bool operator==(const Metadata& another) const;

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -487,6 +487,8 @@ public:
     return view_type(this->sequences.data() + this->offsets[i], this->length(i));
   }
 
+  void remove(size_type i);
+
   std::vector<char>   sequences;
   sdsl::int_vector<0> offsets;
 };

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -478,7 +478,7 @@ class StringArray
 public:
   typedef gbwt::size_type size_type;
 
-  StringArray() : offsets(1, 0) {}
+  StringArray() : index(1, 0) {}
   StringArray(const std::vector<std::string>& source);
   StringArray(const std::map<std::string, std::string>& source);
   StringArray(size_type n, const std::function<size_type(size_type)>& length, const std::function<view_type(size_type)>& sequence);
@@ -497,26 +497,26 @@ public:
   bool operator==(const StringArray& another) const;
   bool operator!=(const StringArray& another) const;
 
-  size_type size() const { return this->offsets.size() - 1; }
+  size_type size() const { return this->index.size() - 1; }
   bool empty() const { return (this->size() == 0); }
-  size_type length() const { return this->sequences.size(); }
-  size_type length(size_type i) const { return (this->offsets[i + 1] - this->offsets[i]); }
-  size_type length(size_type start, size_t limit) const { return (this->offsets[limit] - this->offsets[start]); }
+  size_type length() const { return this->strings.size(); }
+  size_type length(size_type i) const { return (this->index[i + 1] - this->index[i]); }
+  size_type length(size_type start, size_t limit) const { return (this->index[limit] - this->index[start]); }
 
   std::string str(size_type i) const
   {
-    return std::string(this->sequences.data() + this->offsets[i], this->sequences.data() + this->offsets[i + 1]);
+    return std::string(this->strings.data() + this->index[i], this->strings.data() + this->index[i + 1]);
   }
 
   view_type view(size_type i) const
   {
-    return view_type(this->sequences.data() + this->offsets[i], this->length(i));
+    return view_type(this->strings.data() + this->index[i], this->length(i));
   }
 
   void remove(size_type i);
 
-  std::vector<char>   sequences;
-  sdsl::int_vector<0> offsets;
+  sdsl::int_vector<0> index;
+  std::vector<char>   strings;
 
 private:
   // Throws `sdsl::simple_sds::InvalidData` if the checks fail.

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -525,7 +525,9 @@ public:
   // Load the version of Dictionary used in Metadata version 1.
   void load_v1(std::istream& in);
 
-  // FIXME simple-sds
+  void simple_sds_serialize(std::ostream& out) const;
+  void simple_sds_load(std::istream& in);
+  size_t simple_sds_size() const;
 
   bool operator==(const Dictionary& another) const;
   bool operator!=(const Dictionary& another) const { return !(this->operator==(another)); }

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -359,6 +359,9 @@ struct RecordArray
 
 private:
   void copy(const RecordArray& source);
+
+  // Throws `sdsl::simple_sds::InvalidData` if the checks fail.
+  void sanityChecks() const;
 };
 
 //------------------------------------------------------------------------------
@@ -416,6 +419,9 @@ struct DASamples
 private:
   void copy(const DASamples& source);
   void setVectors();
+
+  // Throws `sdsl::simple_sds::InvalidData` if the checks fail.
+  void sanityChecks() const;
 };
 
 //------------------------------------------------------------------------------
@@ -500,6 +506,10 @@ public:
 
   std::vector<char>   sequences;
   sdsl::int_vector<0> offsets;
+
+private:
+  // Throws `sdsl::simple_sds::InvalidData` if the checks fail.
+  void sanityChecks() const;
 };
 
 //------------------------------------------------------------------------------
@@ -566,6 +576,9 @@ public:
 
 private:
   void copy(const Dictionary& source);
+
+  // Throws `sdsl::simple_sds::InvalidData` if the checks fail.
+  void sanityChecks() const;
 
   void sortKeys();
 

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -29,6 +29,7 @@
 #include <gbwt/utils.h>
 
 #include <functional>
+#include <map>
 
 namespace gbwt
 {
@@ -470,6 +471,7 @@ public:
 
   StringArray() : offsets(1, 0) {}
   StringArray(const std::vector<std::string>& source);
+  StringArray(const std::map<std::string, std::string>& source);
   StringArray(size_type n, const std::function<size_type(size_type)>& length, const std::function<view_type(size_type)>& sequence);
   StringArray(size_type n, const std::function<bool(size_type)>& choose, const std::function<size_type(size_type)>& length, const std::function<view_type(size_type)>& sequence);
   StringArray(size_type n, const std::function<size_type(size_type)>& length, const std::function<std::string(size_type)>& sequence);

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -321,7 +321,7 @@ struct RecordArray
 {
   typedef gbwt::size_type size_type;
 
-  size_type                        records;
+  size_type                        records; // This is redundant, as we could use `index.ones()`.
   sdsl::sd_vector<>                index;
   sdsl::sd_vector<>::select_1_type select;
   std::vector<byte_type>           data;
@@ -344,6 +344,10 @@ struct RecordArray
 
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
+
+  void simple_sds_serialize(std::ostream& out) const;
+  void simple_sds_load(std::istream& in);
+  size_t simple_sds_size() const;
 
   size_type size() const { return this->records; }
   bool empty() const { return (this->size() == 0); }
@@ -390,6 +394,10 @@ struct DASamples
 
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);
+
+  void simple_sds_serialize(std::ostream& out) const;
+  void simple_sds_load(std::istream& in);
+  size_t simple_sds_size() const;
 
   size_type records() const { return this->sampled_records.size(); }
   size_type size() const { return this->array.size(); }

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -214,6 +214,9 @@ struct CompressedRecord
   CompressedRecord();
   CompressedRecord(const std::vector<byte_type>& source, size_type start, size_type limit);
 
+  // Returns the size of the record corresponding to the given semiopen interval.
+  static size_type recordSize(const std::vector<byte_type>& source, size_type start, size_type limit);
+
   // Checks whether the record starting at the given position is empty.
   static bool emptyRecord(const std::vector<byte_type>& source, size_type start);
 
@@ -352,6 +355,8 @@ struct RecordArray
 
   size_type size() const { return this->records; }
   bool empty() const { return (this->size() == 0); }
+
+  size_type size(size_type record) const;
   bool empty(size_type record) const { return CompressedRecord::emptyRecord(this->data, this->select(record + 1)); }
 
   // Records use 0-based indexing and semiopen ranges [start, limit).
@@ -390,6 +395,10 @@ struct DASamples
   ~DASamples();
 
   explicit DASamples(const std::vector<DynamicRecord>& bwt);
+
+  // Assumes that the samples are in sorted order.
+  explicit DASamples(const RecordArray& bwt, const std::vector<std::pair<node_type, sample_type>>& samples);
+
   DASamples(const std::vector<DASamples const*> sources, const sdsl::int_vector<0>& origins, const std::vector<size_type>& record_offsets, const std::vector<size_type>& sequence_counts);
 
   void swap(DASamples& another);

--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -239,6 +239,9 @@ struct Version
   constexpr static size_type METADATA_VERSION = 2;
   constexpr static size_type VARIANT_VERSION  = 1;
   constexpr static size_type R_INDEX_VERSION  = 1;
+
+  const static std::string SOURCE_KEY; // Source
+  const static std::string SOURCE_VALUE; // jltsiren/gbwt
 };
 
 //------------------------------------------------------------------------------

--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -233,8 +233,8 @@ struct Version
   constexpr static size_type MINOR_VERSION    = 2;
   constexpr static size_type PATCH_VERSION    = 0;
 
-  constexpr static size_type GBWT_VERSION     = 4;
-  constexpr static size_type METADATA_VERSION = 1;
+  constexpr static size_type GBWT_VERSION     = 5;
+  constexpr static size_type METADATA_VERSION = 2;
   constexpr static size_type VARIANT_VERSION  = 1;
   constexpr static size_type R_INDEX_VERSION  = 1;
 };

--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -240,7 +240,7 @@ struct Version
   constexpr static size_type VARIANT_VERSION  = 1;
   constexpr static size_type R_INDEX_VERSION  = 1;
 
-  const static std::string SOURCE_KEY; // Source
+  const static std::string SOURCE_KEY; // source
   const static std::string SOURCE_VALUE; // jltsiren/gbwt
 };
 

--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -121,6 +121,18 @@ typedef std::vector<node_type>     vector_type;
 
 //------------------------------------------------------------------------------
 
+// In-place view of the sequence: (start, length).
+// This is a quick replacement for std::string_view from C++17.
+typedef std::pair<const char*, size_t> view_type;
+
+inline view_type
+str_to_view(const std::string& str)
+{
+  return view_type(str.data(), str.length());
+}
+
+//------------------------------------------------------------------------------
+
 /*
   range_type stores a closed range [first, second]. Empty ranges are indicated by
   first > second. The emptiness check uses +1 to handle the common special case

--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -30,6 +30,7 @@
 #include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <vector>
 
 #include <sdsl/int_vector.hpp>
@@ -103,9 +104,10 @@ constexpr size_type BILLION      = 1000 * MILLION;
 
 constexpr node_type ENDMARKER    = 0;
 
-constexpr size_type invalid_node() { return ~(node_type)0; }
-constexpr size_type invalid_sequence() { return ~(size_type)0; }
-constexpr size_type invalid_offset() { return ~(size_type)0; }
+constexpr node_type invalid_node() { return std::numeric_limits<node_type>::max(); }
+constexpr comp_type invalid_comp() { return std::numeric_limits<comp_type>::max(); }
+constexpr size_type invalid_sequence() { return std::numeric_limits<size_type>::max(); }
+constexpr size_type invalid_offset() { return std::numeric_limits<size_type>::max(); }
 
 inline constexpr edge_type invalid_edge() { return edge_type(invalid_node(), invalid_offset()); }
 inline constexpr sample_type invalid_sample() { return sample_type(invalid_offset(), invalid_sequence()); }

--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -32,7 +32,9 @@
 #include <iostream>
 #include <vector>
 
-#include <sdsl/bit_vectors.hpp>
+#include <sdsl/int_vector.hpp>
+#include <sdsl/sd_vector.hpp>
+#include <sdsl/simple_sds.hpp>
 
 #include <omp.h>
 

--- a/metadata.cpp
+++ b/metadata.cpp
@@ -32,33 +32,11 @@ namespace gbwt
 
 //------------------------------------------------------------------------------
 
-// Numerical class constants.
-
-constexpr std::uint32_t Metadata::TAG;
-constexpr std::uint32_t Metadata::VERSION;
-constexpr std::uint64_t Metadata::FLAG_MASK;
-constexpr std::uint64_t Metadata::FLAG_PATH_NAMES;
-constexpr std::uint64_t Metadata::FLAG_SAMPLE_NAMES;
-constexpr std::uint64_t Metadata::FLAG_CONTIG_NAMES;
-
-constexpr std::uint32_t Metadata::NAMES_VERSION;
-constexpr std::uint64_t Metadata::NAMES_FLAG_MASK;
-constexpr std::uint32_t Metadata::INITIAL_VERSION;
-constexpr std::uint64_t Metadata::INITIAL_FLAG_MASK;
-
-//------------------------------------------------------------------------------
-
-Metadata::Metadata() :
-  tag(TAG), version(VERSION),
-  sample_count(0), haplotype_count(0), contig_count(0),
-  flags(0)
+Metadata::Metadata()
 {
 }
 
-Metadata::Metadata(std::vector<const Metadata*> sources, bool same_samples, bool same_contigs)  :
-  tag(TAG), version(VERSION),
-  sample_count(0), haplotype_count(0), contig_count(0),
-  flags(0)
+Metadata::Metadata(std::vector<const Metadata*> sources, bool same_samples, bool same_contigs)
 {
   if(sources.empty()) { return; }
 
@@ -75,12 +53,7 @@ Metadata::serialize(std::ostream& out, sdsl::structure_tree_node* v, std::string
   sdsl::structure_tree_node* child = sdsl::structure_tree::add_child(v, name, sdsl::util::class_name(*this));
   size_type written_bytes = 0;
 
-  written_bytes += sdsl::write_member(this->tag, out, child, "tag");
-  written_bytes += sdsl::write_member(this->version, out, child, "version");
-  written_bytes += sdsl::write_member(this->sample_count, out, child, "sample_count");
-  written_bytes += sdsl::write_member(this->haplotype_count, out, child, "haplotype_count");
-  written_bytes += sdsl::write_member(this->contig_count, out, child, "contig_count");
-  written_bytes += sdsl::write_member(this->flags, out, child, "flags");
+  written_bytes += this->header.serialize(out, child, "header");
 
   if(this->hasPathNames())
   {
@@ -102,19 +75,13 @@ Metadata::serialize(std::ostream& out, sdsl::structure_tree_node* v, std::string
 void
 Metadata::load(std::istream& in)
 {
-  sdsl::read_member(this->tag, in);
-  sdsl::read_member(this->version, in);
-  sdsl::read_member(this->sample_count, in);
-  sdsl::read_member(this->haplotype_count, in);
-  sdsl::read_member(this->contig_count, in);
-  sdsl::read_member(this->flags, in);
-
-  // Check the header.
-  if(!(this->check()))
+  // Load and check the header.
+  this->header.load(in);
+  if(!(this->header.check()))
   {
     std::cerr << "Metadata::load(): Invalid metadata: " << *this << std::endl;
   }
-  this->setVersion(); // Update to the current version.
+  this->header.setVersion(); // Update to the current version.
 
   if(this->hasPathNames())
   {
@@ -130,35 +97,12 @@ Metadata::load(std::istream& in)
   }
 }
 
-bool
-Metadata::check() const
-{
-  if(this->tag != TAG) { return false; }
-  switch(this->version)
-  {
-  case VERSION:
-    return ((this->flags & FLAG_MASK) == this->flags);
-  case NAMES_VERSION:
-    return ((this->flags & NAMES_FLAG_MASK) == this->flags);
-  case INITIAL_VERSION:
-    return ((this->flags & INITIAL_FLAG_MASK) == this->flags);
-  default:
-    return false;
-  }
-}
-
 void
 Metadata::swap(Metadata& another)
 {
   if(this != &another)
   {
-    std::swap(this->tag, another.tag);
-    std::swap(this->version, another.version);
-    std::swap(this->sample_count, another.sample_count);
-    std::swap(this->haplotype_count, another.haplotype_count);
-    std::swap(this->contig_count, another.contig_count);
-    std::swap(this->flags, another.flags);
-
+    this->header.swap(another.header);
     this->path_names.swap(another.path_names);
     this->sample_names.swap(another.sample_names);
     this->contig_names.swap(another.contig_names);
@@ -168,12 +112,7 @@ Metadata::swap(Metadata& another)
 bool
 Metadata::operator==(const Metadata& another) const
 {
-  return (this->tag == another.tag &&
-          this->version == another.version &&
-          this->sample_count == another.sample_count &&
-          this->haplotype_count == another.haplotype_count &&
-          this->contig_count == another.contig_count &&
-          this->flags == another.flags &&
+  return (this->header == another.header &&
           this->path_names == another.path_names &&
           this->sample_names == another.sample_names &&
           this->contig_names == another.contig_names);
@@ -188,13 +127,13 @@ Metadata::setSamples(size_type n)
   {
     std::cerr << "Metadata::setSamples(): Warning: Changing sample count without changing sample names" << std::endl;
   }
-  this->sample_count = n;
+  this->header.sample_count = n;
 }
 
 void
 Metadata::setHaplotypes(size_type n)
 {
-  this->haplotype_count = n;
+  this->header.haplotype_count = n;
 }
 
 void
@@ -204,7 +143,7 @@ Metadata::setContigs(size_type n)
   {
     std::cerr << "Metadata::setContigs(): Warning: Changing contig count without changing contig names" << std::endl;
   }
-  this->contig_count = n;
+  this->header.contig_count = n;
 }
 
 //------------------------------------------------------------------------------
@@ -255,14 +194,14 @@ Metadata::pathsForContig(size_type contig_id) const
 void
 Metadata::addPath(const PathName& path)
 {
-  this->set(FLAG_PATH_NAMES);
+  this->header.set(MetadataHeader::FLAG_PATH_NAMES);
   this->path_names.emplace_back(path);
 }
 
 void
 Metadata::addPath(size_type sample, size_type contig, size_type phase, size_type count)
 {
-  this->set(FLAG_PATH_NAMES);
+  this->header.set(MetadataHeader::FLAG_PATH_NAMES);
   PathName path =
   {
     static_cast<PathName::path_name_type>(sample),
@@ -276,7 +215,7 @@ Metadata::addPath(size_type sample, size_type contig, size_type phase, size_type
 void
 Metadata::clearPathNames()
 {
-  this->unset(FLAG_PATH_NAMES);
+  this->header.unset(MetadataHeader::FLAG_PATH_NAMES);
   this->path_names = std::vector<PathName>();
 }
 
@@ -292,7 +231,7 @@ Metadata::setSamples(const std::vector<std::string>& names)
   }
 
   this->setSamples(names.size());
-  this->set(FLAG_SAMPLE_NAMES);
+  this->header.set(MetadataHeader::FLAG_SAMPLE_NAMES);
   this->sample_names = Dictionary(names);
 }
 
@@ -304,13 +243,13 @@ Metadata::addSamples(const std::vector<std::string>& names)
   Dictionary additional_names(names);
   this->sample_names.append(additional_names);
   this->setSamples(this->sample_names.size());
-  this->set(FLAG_SAMPLE_NAMES);
+  this->header.set(MetadataHeader::FLAG_SAMPLE_NAMES);
 }
 
 void
 Metadata::clearSampleNames()
 {
-  this->unset(FLAG_SAMPLE_NAMES);
+  this->header.unset(MetadataHeader::FLAG_SAMPLE_NAMES);
   this->sample_names.clear();
 }
 
@@ -326,7 +265,7 @@ Metadata::setContigs(const std::vector<std::string>& names)
   }
 
   this->setContigs(names.size());
-  this->set(FLAG_CONTIG_NAMES);
+  this->header.set(MetadataHeader::FLAG_CONTIG_NAMES);
   this->contig_names = Dictionary(names);
 }
 
@@ -338,13 +277,13 @@ Metadata::addContigs(const std::vector<std::string>& names)
   Dictionary additional_names(names);
   this->contig_names.append(additional_names);
   this->setContigs(this->contig_names.size());
-  this->set(FLAG_CONTIG_NAMES);
+  this->header.set(MetadataHeader::FLAG_CONTIG_NAMES);
 }
 
 void
 Metadata::clearContigNames()
 {
-  this->unset(FLAG_CONTIG_NAMES);
+  this->header.unset(MetadataHeader::FLAG_CONTIG_NAMES);
   this->contig_names.clear();
 }
 
@@ -412,8 +351,8 @@ Metadata::removeSample(size_type sample_id)
 
   // Update samples and haplotypes.
   if(this->hasSampleNames()) { this->sample_names.remove(sample_id); }
-  this->sample_count--;
-  this->haplotype_count -= haplotypes_to_remove;
+  this->header.sample_count--;
+  this->header.haplotype_count -= haplotypes_to_remove;
 
   return result;
 }
@@ -439,7 +378,7 @@ Metadata::removeContig(size_type contig_id)
 
   // Update contigs.
   if(this->hasContigNames()) { this->contig_names.remove(contig_id); }
-  this->contig_count--;
+  this->header.contig_count--;
 
   return result;
 }
@@ -464,10 +403,10 @@ Metadata::merge(const Metadata& source, bool same_samples, bool same_contigs)
       {
         std::cerr << "Metadata::merge(): Warning: Estimating new haplotype count" << std::endl;
       }
-      double added_samples = this->sample_names.size() - this->sample_count;
-      this->haplotype_count += (added_samples * source.haplotypes()) / source.samples();
+      double added_samples = this->sample_names.size() - this->header.sample_count;
+      this->header.haplotype_count += (added_samples * source.haplotypes()) / source.samples();
     }
-    this->sample_count = this->sample_names.size();
+    this->header.sample_count = this->sample_names.size();
   }
   else if(same_samples)
   {
@@ -485,14 +424,14 @@ Metadata::merge(const Metadata& source, bool same_samples, bool same_contigs)
         std::cerr << "Metadata::merge(): Warning: Taking sample names from the source" << std::endl;
       }
       this->sample_names = source.sample_names;
-      this->set(FLAG_SAMPLE_NAMES);
+      this->header.set(MetadataHeader::FLAG_SAMPLE_NAMES);
     }
   }
   else
   {
     source_sample_offset = this->samples();
-    this->sample_count += source.samples();
-    this->haplotype_count += source.haplotypes();
+    this->header.sample_count += source.samples();
+    this->header.haplotype_count += source.haplotypes();
     if(this->hasSampleNames())
     {
       if(Verbosity::level >= Verbosity::FULL)
@@ -507,7 +446,7 @@ Metadata::merge(const Metadata& source, bool same_samples, bool same_contigs)
   if(merge_contig_names)
   {
     this->contig_names = Dictionary(this->contig_names, source.contig_names);
-    this->contig_count = this->contig_names.size();
+    this->header.contig_count = this->contig_names.size();
   }
   else if(same_contigs)
   {
@@ -522,13 +461,13 @@ Metadata::merge(const Metadata& source, bool same_samples, bool same_contigs)
         std::cerr << "Metadata::merge(): Warning: Taking contig names from the source" << std::endl;
       }
       this->contig_names = source.contig_names;
-      this->set(FLAG_CONTIG_NAMES);
+      this->header.set(MetadataHeader::FLAG_CONTIG_NAMES);
     }
   }
   else
   {
     source_contig_offset = this->contigs();
-    this->contig_count += source.contigs();
+    this->header.contig_count += source.contigs();
     if(this->hasContigNames())
     {
       if(Verbosity::level >= Verbosity::FULL)
@@ -565,7 +504,7 @@ Metadata::merge(const Metadata& source, bool same_samples, bool same_contigs)
       {
         found_haplotypes.emplace(path.sample, path.phase);
       }
-      this->haplotype_count = found_haplotypes.size();
+      this->header.haplotype_count = found_haplotypes.size();
     }
   }
   else if(this->hasPathNames())
@@ -588,19 +527,19 @@ Metadata::clear()
 
 std::ostream& operator<<(std::ostream& stream, const Metadata& metadata)
 {
-  if(metadata.get(Metadata::FLAG_PATH_NAMES))
+  if(metadata.hasPathNames())
   {
     stream << metadata.paths() << " paths with names, ";
   }
 
   stream << metadata.samples() << " samples";
-  if(metadata.get(Metadata::FLAG_SAMPLE_NAMES)) { stream << " with names"; }
+  if(metadata.hasSampleNames()) { stream << " with names"; }
   stream << ", ";
 
   stream << metadata.haplotypes() << " haplotypes, ";
 
   stream << metadata.contigs() << " contigs";
-  if(metadata.get(Metadata::FLAG_CONTIG_NAMES)) { stream << " with names"; }
+  if(metadata.hasContigNames()) { stream << " with names"; }
 
   return stream;
 }

--- a/metadata.cpp
+++ b/metadata.cpp
@@ -25,8 +25,6 @@
 #include <gbwt/internal.h>
 #include <gbwt/metadata.h>
 
-#include <sdsl/simple_sds.hpp>
-
 #include <set>
 
 namespace gbwt

--- a/metadata.cpp
+++ b/metadata.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019, 2020 Jouni Siren
+  Copyright (c) 2019, 2020, 2021 Jouni Siren
 
   Author: Jouni Siren <jouni.siren@iki.fi>
 
@@ -40,6 +40,9 @@ constexpr std::uint64_t Metadata::FLAG_MASK;
 constexpr std::uint64_t Metadata::FLAG_PATH_NAMES;
 constexpr std::uint64_t Metadata::FLAG_SAMPLE_NAMES;
 constexpr std::uint64_t Metadata::FLAG_CONTIG_NAMES;
+
+constexpr std::uint32_t Metadata::NAMES_VERSION;
+constexpr std::uint64_t Metadata::NAMES_FLAG_MASK;
 constexpr std::uint32_t Metadata::INITIAL_VERSION;
 constexpr std::uint64_t Metadata::INITIAL_FLAG_MASK;
 
@@ -135,6 +138,8 @@ Metadata::check() const
   {
   case VERSION:
     return ((this->flags & FLAG_MASK) == this->flags);
+  case NAMES_VERSION:
+    return ((this->flags & NAMES_FLAG_MASK) == this->flags);
   case INITIAL_VERSION:
     return ((this->flags & INITIAL_FLAG_MASK) == this->flags);
   default:

--- a/metadata.cpp
+++ b/metadata.cpp
@@ -101,6 +101,46 @@ Metadata::load(std::istream& in)
 }
 
 void
+Metadata::simple_sds_serialize(std::ostream& out) const
+{
+  sdsl::simple_sds::serialize_value(this->header, out);
+  sdsl::simple_sds::serialize_vector(this->path_names, out);
+  this->sample_names.simple_sds_serialize(out);
+  this->contig_names.simple_sds_serialize(out);
+}
+
+void
+Metadata::simple_sds_load(std::istream& in)
+{
+  this->header = sdsl::simple_sds::load_value<MetadataHeader>(in);
+  if(!(this->header.check_simple_sds()))
+  {
+    throw sdsl::simple_sds::InvalidData("Metadata: Invalid header");
+  }
+
+  this->path_names = sdsl::simple_sds::load_vector<PathName>(in);
+  this->sample_names.simple_sds_load(in);
+  if(this->header.sample_count != this->sample_names.size())
+  {
+    throw sdsl::simple_sds::InvalidData("Metadata: Invalid number of sample names");
+  }
+  this->contig_names.simple_sds_load(in);
+  if(this->header.contig_count != this->contig_names.size())
+  {
+    throw sdsl::simple_sds::InvalidData("Metadata: Invalid number of contig names");
+  }
+}
+
+size_t
+Metadata::simple_sds_size() const
+{
+  return sdsl::simple_sds::value_size(this->header) +
+    sdsl::simple_sds::vector_size(this->path_names) +
+    this->sample_names.simple_sds_size() +
+    this->contig_names.simple_sds_size();
+}
+
+void
 Metadata::swap(Metadata& another)
 {
   if(this != &another)

--- a/metadata.cpp
+++ b/metadata.cpp
@@ -25,6 +25,8 @@
 #include <gbwt/internal.h>
 #include <gbwt/metadata.h>
 
+#include <sdsl/simple_sds.hpp>
+
 #include <set>
 
 namespace gbwt
@@ -79,7 +81,7 @@ Metadata::load(std::istream& in)
   this->header.load(in);
   if(!(this->header.check()))
   {
-    std::cerr << "Metadata::load(): Invalid metadata: " << *this << std::endl;
+    throw sdsl::simple_sds::InvalidData("Metadata: Invalid header");
   }
   bool old_version = (this->header.version < MetadataHeader::VERSION);
   this->header.setVersion(); // Update to the current version.

--- a/metadata.cpp
+++ b/metadata.cpp
@@ -81,6 +81,7 @@ Metadata::load(std::istream& in)
   {
     std::cerr << "Metadata::load(): Invalid metadata: " << *this << std::endl;
   }
+  bool old_version = (this->header.version < MetadataHeader::VERSION);
   this->header.setVersion(); // Update to the current version.
 
   if(this->hasPathNames())
@@ -89,11 +90,13 @@ Metadata::load(std::istream& in)
   }
   if(this->hasSampleNames())
   {
-    this->sample_names.load(in);
+    if(old_version) { this->sample_names.load_v1(in); }
+    else { this->sample_names.load(in); }
   }
   if(this->hasContigNames())
   {
-    this->contig_names.load(in);
+    if(old_version) { this->contig_names.load_v1(in); }
+    else { this->contig_names.load(in); }
   }
 }
 

--- a/metadata_tool.cpp
+++ b/metadata_tool.cpp
@@ -40,22 +40,25 @@ main(int argc, char** argv)
   if(argc < 2) { printUsage(); }
 
   int c = 0;
-  bool print_metadata = true;
-  bool list_samples = false, list_contigs = false, list_paths = false;
+  bool print_metadata = true, need_metadata = false;
+  bool list_samples = false, list_contigs = false, list_paths = false, list_tags = false;
   bool remove_metadata = false;
   bool sdsl_format = false;
-  while((c = getopt(argc, argv, "scprO")) != -1)
+  while((c = getopt(argc, argv, "scptrO")) != -1)
   {
     switch(c)
     {
     case 's':
-      list_samples = true; print_metadata = false;
+      list_samples = true; print_metadata = false; need_metadata = true;
       break;
     case 'c':
-      list_contigs = true; print_metadata = false;
+      list_contigs = true; print_metadata = false; need_metadata = true;
       break;
     case 'p':
-      list_paths = true; print_metadata = false;
+      list_paths = true; print_metadata = false; need_metadata = true;
+      break;
+    case 't':
+      list_tags = true; print_metadata = false;
       break;
     case 'r':
       remove_metadata = true;
@@ -75,7 +78,7 @@ main(int argc, char** argv)
 
   GBWT index;
   sdsl::simple_sds::load_from(index, index_base + GBWT::EXTENSION);
-  if(!(index.hasMetadata()))
+  if(!(index.hasMetadata()) && need_metadata)
   {
     std::cerr << "metadata_tool: No metadata in the GBWT index" << std::endl;
     std::exit(EXIT_FAILURE);
@@ -129,6 +132,13 @@ main(int argc, char** argv)
       std::cout << ", " << path.phase << ", " << path.count << ")" << std::endl;
     }
   }
+  if(list_tags)
+  {
+    for(auto iter = index.tags.begin(); iter != index.tags.end(); ++iter)
+    {
+      std::cout << iter->first << " = " << iter->second << std::endl;
+    }
+  }
   if(remove_metadata)
   {
     index.clearMetadata();
@@ -162,6 +172,7 @@ printUsage(int exit_code)
   std::cerr << "  -s    List sample names" << std::endl;
   std::cerr << "  -c    List contig names" << std::endl;
   std::cerr << "  -p    List path names" << std::endl;
+  std::cerr << "  -t    List tags" << std::endl;
   std::cerr << "  -r    Remove all metadata" << std::endl;
   std::cerr << "  -O    Output SDSL format instead of simple-sds format" << std::endl;
   std::cerr << std::endl;

--- a/support.cpp
+++ b/support.cpp
@@ -1499,6 +1499,16 @@ StringArray::StringArray(const std::vector<std::string>& source)
   });
 }
 
+StringArray::StringArray(const std::map<std::string, std::string>& source)
+{
+  std::vector<std::string> linearized;
+  for(auto iter = source.begin(); iter != source.end(); ++iter)
+  {
+    linearized.push_back(iter->first); linearized.push_back(iter->second);
+  }
+  *this = StringArray(linearized);
+}
+
 StringArray::StringArray(size_type n, const std::function<size_type(size_type)>& length, const std::function<view_type(size_type)>& sequence)
 {
   *this = StringArray(n, [](size_type) -> bool

--- a/support.cpp
+++ b/support.cpp
@@ -1756,6 +1756,31 @@ Dictionary::load_v1(std::istream& in)
 }
 
 void
+Dictionary::simple_sds_serialize(std::ostream& out) const
+{
+  this->strings.simple_sds_serialize(out);
+  this->sorted_ids.simple_sds_serialize(out);
+}
+
+void
+Dictionary::simple_sds_load(std::istream& in)
+{
+  this->strings.simple_sds_load(in);
+  this->sorted_ids.simple_sds_load(in);
+
+  if(this->sorted_ids.size() != this->strings.size())
+  {
+    throw sdsl::simple_sds::InvalidData("Dictionary: size mismatch between strings and sorted ids");
+  }
+}
+
+size_t
+Dictionary::simple_sds_size() const
+{
+  return this->strings.simple_sds_size() + this->sorted_ids.simple_sds_size();
+}
+
+void
 Dictionary::copy(const Dictionary& source)
 {
   this->strings = source.strings;

--- a/support.cpp
+++ b/support.cpp
@@ -25,8 +25,6 @@
 
 #include <gbwt/internal.h>
 
-#include <sdsl/simple_sds.hpp>
-
 #include <unordered_set>
 
 namespace gbwt

--- a/support.cpp
+++ b/support.cpp
@@ -1585,6 +1585,30 @@ StringArray::simple_sds_size() const
   return result;
 }
 
+void
+StringArray::remove(size_type i)
+{
+  if(i >= this->size()) { return; }
+
+  // Update sequences.
+  size_type tail = this->offsets[i];
+  size_type diff = this->offsets[i + 1] - tail;
+  while(tail + diff < this->sequences.size())
+  {
+    this->sequences[tail] = this->sequences[tail + diff];
+    tail++;
+  }
+  this->sequences.resize(tail);
+
+  // Update offsets.
+  for(size_type j = i; j + 1 < this->offsets.size(); j++)
+  {
+    this->offsets[j] = this->offsets[j + 1] - diff;
+  }
+  this->offsets.resize(this->offsets.size() - 1);
+  sdsl::util::bit_compress(this->offsets);
+}
+
 bool
 StringArray::operator==(const StringArray& another) const
 {

--- a/support.cpp
+++ b/support.cpp
@@ -1770,7 +1770,7 @@ Dictionary::simple_sds_load(std::istream& in)
 
   if(this->sorted_ids.size() != this->strings.size())
   {
-    throw sdsl::simple_sds::InvalidData("Dictionary: size mismatch between strings and sorted ids");
+    throw sdsl::simple_sds::InvalidData("Dictionary: Size mismatch between strings and sorted ids");
   }
 }
 

--- a/support.cpp
+++ b/support.cpp
@@ -1546,6 +1546,12 @@ StringArray::simple_sds_load(std::istream& in)
     for(auto iter = v.one_begin(); iter != v.one_end(); ++iter, i++) { this->offsets[i] = iter->second; }
     sdsl::util::bit_compress(this->offsets);
   }
+
+  // FIXME sanity checks
+  if(this->offsets.size() == 0 || this->offsets[0] != 0 || this->offsets[this->offsets.size() - 1] != this->sequences.size())
+  {
+    throw sdsl::simple_sds::InvalidData("StringArray: offsets and sequences do not match");
+  }
 }
 
 size_t

--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -1,5 +1,5 @@
 /*
-  Copyright (c) 2019 Jouni Siren
+  Copyright (c) 2019, 2021 Jouni Siren
 
   Author: Jouni Siren <jouni.siren@iki.fi>
 
@@ -112,7 +112,6 @@ public:
 
     Metadata merged = first;
     merged.merge(second, same_samples, false);
-    ASSERT_TRUE(merged.check()) << "Merged metadata object is not in a valid state " << test_name;
     ASSERT_EQ(merged.samples(), correct_count) << "Expected " << correct_count << " samples, got " << merged.samples() << " " << test_name;
     testMergeConstructor(first, second, merged, same_samples, false, test_name);
 
@@ -175,7 +174,6 @@ public:
 
     Metadata merged = first;
     merged.merge(second, false, same_contigs);
-    ASSERT_TRUE(merged.check()) << "Merged metadata object is not in a valid state " << test_name;
     ASSERT_EQ(merged.contigs(), correct_count) << "Expected " << correct_count << " contigs, got " << merged.contigs() << " " << test_name;
     testMergeConstructor(first, second, merged, false, same_contigs, test_name);
 
@@ -228,7 +226,6 @@ public:
 
     Metadata merged = first;
     merged.merge(second, same, same);
-    ASSERT_TRUE(merged.check()) << "Merged metadata object is not in a valid state " << test_name;
     ASSERT_TRUE(merged.hasPathNames()) << "Merged metadata object does not have path names" << test_name;
     ASSERT_EQ(merged.paths(), correct_count) << "Expected " << correct_count << " paths, got " << merged.paths() << " " << test_name;
     testMergeConstructor(first, second, merged, same, same, test_name);
@@ -293,7 +290,6 @@ TEST_F(MetadataTest, BasicTest)
 {
   // Empty metadata.
   Metadata empty;
-  ASSERT_TRUE(empty.check()) << "Empty metadata object is not in a valid state";
   EXPECT_EQ(empty.samples(), static_cast<size_type>(0)) << "Empty metadata object contains samples";
   EXPECT_EQ(empty.haplotypes(), static_cast<size_type>(0)) << "Empty metadata object contains haplotypes";
   EXPECT_EQ(empty.contigs(), static_cast<size_type>(0)) << "Empty metadata object contains contigs";
@@ -307,7 +303,6 @@ TEST_F(MetadataTest, BasicTest)
   nonempty.setSamples(samples);
   nonempty.setHaplotypes(haplotypes);
   nonempty.setContigs(contigs);
-  ASSERT_TRUE(nonempty.check()) << "Metadata object is not in a valid state";
   EXPECT_EQ(nonempty.samples(), samples) << "Expected " << samples << " samples, got " << nonempty.samples();
   EXPECT_EQ(nonempty.haplotypes(), haplotypes) << "Expected " << haplotypes << " haplotypes, got " << nonempty.haplotypes();
   EXPECT_EQ(nonempty.contigs(), contigs) << "Expected " << contigs << " contigs, got " << nonempty.contigs();
@@ -324,7 +319,6 @@ TEST_F(MetadataTest, Samples)
 {
   Metadata metadata;
   metadata.setSamples(keys);
-  ASSERT_TRUE(metadata.check()) << "Metadata object with sample names is not in a valid state";
   EXPECT_TRUE(metadata.hasSampleNames()) << "Metadata object does not contain sample names";
   ASSERT_EQ(metadata.samples(), static_cast<size_type>(keys.size())) << "Sample count is incorrect";
   bool ok = true;
@@ -345,7 +339,6 @@ TEST_F(MetadataTest, Samples)
   }
 
   metadata.clearSampleNames();
-  ASSERT_TRUE(metadata.check()) << "Metadata object is not in a valid state after clearing sample names";
   EXPECT_FALSE(metadata.hasSampleNames()) << "Metadata object contains sample names";
   EXPECT_EQ(metadata.samples(), static_cast<size_type>(keys.size())) << "Clearing sample names also cleared sample count";
 }
@@ -410,7 +403,6 @@ TEST_F(MetadataTest, Contigs)
 {
   Metadata metadata;
   metadata.setContigs(keys);
-  ASSERT_TRUE(metadata.check()) << "Metadata object with contig names is not in a valid state";
   EXPECT_TRUE(metadata.hasContigNames()) << "Metadata object does not contain contig names";
   ASSERT_EQ(metadata.contigs(), static_cast<size_type>(keys.size())) << "Contig count is incorrect";
   bool ok = true;
@@ -431,7 +423,6 @@ TEST_F(MetadataTest, Contigs)
   }
 
   metadata.clearContigNames();
-  ASSERT_TRUE(metadata.check()) << "Metadata object is not in a valid state after clearing contig names";
   EXPECT_FALSE(metadata.hasContigNames()) << "Metadata object contains contig names";
   EXPECT_EQ(metadata.contigs(), static_cast<size_type>(keys.size())) << "Clearing contig names also cleared contig count";
 }
@@ -497,7 +488,6 @@ TEST_F(MetadataTest, Paths)
 {
   Metadata metadata;
   for(const PathName& path : paths) { metadata.addPath(path); }
-  ASSERT_TRUE(metadata.check()) << "Metadata object with path names is not in a valid state";
   EXPECT_TRUE(metadata.hasPathNames()) << "Metadata object does not contain path names";
   ASSERT_EQ(metadata.paths(), static_cast<size_type>(paths.size())) << "Path count is incorrect";
   bool ok = true;
@@ -541,7 +531,6 @@ TEST_F(MetadataTest, Paths)
   }
 
   metadata.clearPathNames();
-  ASSERT_TRUE(metadata.check()) << "Metadata object is not in a valid state after clearing path names";
   EXPECT_FALSE(metadata.hasPathNames()) << "Metadata object contains path names";
 }
 

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -57,6 +57,17 @@ public:
     }
   }
 
+  void try_remove(const std::vector<std::string>& original, size_type i) const
+  {
+    std::vector<std::string> copy = original;
+    if(i < original.size()) { copy.erase(copy.begin() + i); }
+    StringArray truth(copy);
+
+    StringArray removed(original);
+    removed.remove(i);
+    EXPECT_EQ(removed, truth) << "Remove failed for " << i << " / " << original.size();
+  }
+
   void check_file_size(const StringArray& original, std::ifstream& in) const
   {
     size_type expected_size = original.simple_sds_size() * sizeof(sdsl::simple_sds::element_type);
@@ -90,6 +101,29 @@ TEST_F(StringArrayTest, NonEmptyArray)
   };
   StringArray array(truth);
   this->check_array(array, truth);
+}
+
+TEST_F(StringArrayTest, Remove)
+{
+  // Try removing the string at each position of the original array.
+  std::vector<std::string> original
+  {
+    "first",
+    "second",
+    "third",
+    "fourth"
+  };
+  for(size_type i = 0; i <= original.size(); i++)
+  {
+    this->try_remove(original, i);
+  }
+
+  // Try removing the only string.
+  std::vector<std::string> one
+  {
+    "one"
+  };
+  this->try_remove(one, 0);
 }
 
 TEST_F(StringArrayTest, SerializeEmpty)

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -390,13 +390,19 @@ TEST(DictionaryTest, Serialization)
   };
   Dictionary original(keys);
 
-  std::string filename = TempFile::getName("Dictionary");
-  sdsl::store_to_file(original, filename);
-  Dictionary copy;
-  sdsl::load_from_file(copy, filename);
-  TempFile::remove(filename);
+  std::string sdsl_filename = TempFile::getName("Dictionary");
+  sdsl::store_to_file(original, sdsl_filename);
+  Dictionary sdsl_copy;
+  sdsl::load_from_file(sdsl_copy, sdsl_filename);
+  TempFile::remove(sdsl_filename);
+  EXPECT_EQ(original, sdsl_copy) << "SDSL serialization failed";
 
-  EXPECT_EQ(original, copy) << "Dictionary serialization failed";
+  std::string simple_sds_filename = TempFile::getName("Dictionary");
+  sdsl::simple_sds::serialize_to(original, simple_sds_filename);
+  Dictionary simple_sds_copy;
+  sdsl::simple_sds::load_from(simple_sds_copy, simple_sds_filename);
+  TempFile::remove(simple_sds_filename);
+  EXPECT_EQ(original, simple_sds_copy) << "Simple-SDS serialization failed";
 }
 
 //------------------------------------------------------------------------------

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -94,12 +94,34 @@ TEST_F(StringArrayTest, NonEmptyArray)
 {
   std::vector<std::string> truth
   {
-    "first",
-    "second",
-    "third",
-    "fourth"
+    "first", "second", "third", "fourth"
   };
   StringArray array(truth);
+  this->check_array(array, truth);
+}
+
+TEST_F(StringArrayTest, Choose)
+{
+  std::vector<std::string> original
+  {
+    "first", "second", "third", "fourth"
+  };
+  std::vector<std::string> truth
+  {
+    "second", "fourth"
+  };
+
+  // Choose odd positions (that contain even numbers).
+  StringArray array(original.size(), [](size_type i) -> bool
+  {
+    return ((i & 1) != 0);
+  }, [&original](size_type i) -> size_type
+  {
+    return original[i].length();
+  }, [&original](size_type i) -> view_type
+  {
+    return str_to_view(original[i]);
+  });
   this->check_array(array, truth);
 }
 
@@ -108,10 +130,7 @@ TEST_F(StringArrayTest, Remove)
   // Try removing the string at each position of the original array.
   std::vector<std::string> original
   {
-    "first",
-    "second",
-    "third",
-    "fourth"
+    "first", "second", "third", "fourth"
   };
   for(size_type i = 0; i <= original.size(); i++)
   {

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -389,18 +389,21 @@ TEST(DictionaryTest, Serialization)
     "first", "second", "third", "fourth", "fifth"
   };
   Dictionary original(keys);
+  size_t expected_size = original.simple_sds_size() * sizeof(sdsl::simple_sds::element_type);
 
   std::string sdsl_filename = TempFile::getName("Dictionary");
   sdsl::store_to_file(original, sdsl_filename);
-  Dictionary sdsl_copy;
-  sdsl::load_from_file(sdsl_copy, sdsl_filename);
+  Dictionary sdsl_copy; sdsl::load_from_file(sdsl_copy, sdsl_filename);
   TempFile::remove(sdsl_filename);
   EXPECT_EQ(original, sdsl_copy) << "SDSL serialization failed";
 
   std::string simple_sds_filename = TempFile::getName("Dictionary");
   sdsl::simple_sds::serialize_to(original, simple_sds_filename);
-  Dictionary simple_sds_copy;
-  sdsl::simple_sds::load_from(simple_sds_copy, simple_sds_filename);
+  std::ifstream in(simple_sds_filename, std::ios_base::binary);
+  size_t bytes = fileSize(in);
+  ASSERT_EQ(bytes, expected_size) << "Invalid Simple-SDS file size";
+  Dictionary simple_sds_copy; simple_sds_copy.simple_sds_load(in);
+  in.close();
   TempFile::remove(simple_sds_filename);
   EXPECT_EQ(original, simple_sds_copy) << "Simple-SDS serialization failed";
 }

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -100,6 +100,22 @@ TEST_F(StringArrayTest, NonEmptyArray)
   this->check_array(array, truth);
 }
 
+TEST_F(StringArrayTest, FromMap)
+{
+  std::map<std::string, std::string> source
+  {
+    { "A-key", "A-value" },
+    { "C-key", "C-value" },
+    { "B-key", "B-value" },
+  };
+  std::vector<std::string> truth
+  {
+    "A-key", "A-value", "B-key", "B-value", "C-key", "C-value"
+  };
+  StringArray array(source);
+  this->check_array(array, truth);
+}
+
 TEST_F(StringArrayTest, Choose)
 {
   std::vector<std::string> original

--- a/utils.cpp
+++ b/utils.cpp
@@ -57,6 +57,13 @@ constexpr size_type Version::R_INDEX_VERSION;
 
 //------------------------------------------------------------------------------
 
+// Other class variables.
+
+const std::string Version::SOURCE_KEY = "Source";
+const std::string Version::SOURCE_VALUE = "jltsiren/gbwt";
+
+//------------------------------------------------------------------------------
+
 std::vector<range_type>
 Range::partition(range_type range, size_type blocks)
 {

--- a/utils.cpp
+++ b/utils.cpp
@@ -59,7 +59,7 @@ constexpr size_type Version::R_INDEX_VERSION;
 
 // Other class variables.
 
-const std::string Version::SOURCE_KEY = "Source";
+const std::string Version::SOURCE_KEY = "source";
 const std::string Version::SOURCE_VALUE = "jltsiren/gbwt";
 
 //------------------------------------------------------------------------------

--- a/variants.cpp
+++ b/variants.cpp
@@ -25,8 +25,6 @@
 #include <gbwt/variants.h>
 #include <gbwt/internal.h>
 
-#include <sdsl/simple_sds.hpp>
-
 #include <string>
 
 namespace gbwt

--- a/variants.cpp
+++ b/variants.cpp
@@ -25,6 +25,8 @@
 #include <gbwt/variants.h>
 #include <gbwt/internal.h>
 
+#include <sdsl/simple_sds.hpp>
+
 #include <string>
 
 namespace gbwt
@@ -183,8 +185,7 @@ VariantPaths::load(std::istream& in)
   // Check header.
   if(!(this->check()))
   {
-    std::cerr << "VariantPaths::load(): Invalid header: ("
-              << this->tag << ", " << this->version << ", " << this->flags << ")" << std::endl;
+    throw sdsl::simple_sds::InvalidData("VariantPaths: Invalid header");
   }
   this->setVersion(); // Update to the current version.
 


### PR DESCRIPTION
This introduces GBWT file format version 5 and metadata file format version 2. Structures are now serialized using [simple-sds structures](https://github.com/jltsiren/simple-sds/blob/main/SERIALIZATION.md) by default. Old files based on SDSL structures can still be read, and the new versions can also be serialized using SDSL structures.

The simple-sds format is documented at: https://github.com/jltsiren/gbwt/blob/simple-sds/SERIALIZATION.md

SDSL version 2.3 (vgteam fork) is now required.
