### PR TITLE
Support empty paths

### DIFF
--- a/SERIALIZATION.md
+++ b/SERIALIZATION.md
@@ -1,6 +1,6 @@
 # Simple-SDS serialization format
 
-GBWT version 5, Metadata version 2. Updated 2021-10-11.
+GBWT version 5, Metadata version 2. Updated 2021-11-23.
 
 ## Basics
 
@@ -89,7 +89,7 @@ The `sigma < 255` condition was chosen for compatibility with older GBWT indexes
 The **GBWT** is a run-length encoded FM-index storing integer sequences.
 The integers are interpreted as node identifiers and the sequences as paths in a graph.
 Each path starts from a special **endmarker** node 0, which does not exist in the graph.
-There must be at least one real node in addition to the endmarker on each path.
+**Empty paths** containing only the endmarker are supported but discouraged.
 
 Serialization format for the GBWT:
 

--- a/src/dynamic_gbwt.cpp
+++ b/src/dynamic_gbwt.cpp
@@ -1345,7 +1345,8 @@ buildRA(const DynamicGBWT& left, const DynamicGBWT& right, MergeBuffers& buffers
     buffers.insert(edge_type(ENDMARKER, left.sequences()), thread);
 
     // Computing LF() at the endmarker can be expensive, so we do it using the incoming
-    // edges at the destination node instead.
+    // edges at the destination node instead. If the sequence is empty, countUntil().
+    // will return 0, because the endmarker does not have incoming edges.
     edge_type right_pos = right_endmarker.LF(sequence);
     edge_type left_pos(right_pos.first, left.record(right_pos.first).countUntil(ENDMARKER));
 

--- a/src/fast_locate.cpp
+++ b/src/fast_locate.cpp
@@ -253,7 +253,7 @@ FastLocate::FastLocate(const GBWT& source) :
     for(size_type i = 1; i < this->index->sequences(); i++)
     {
       edge_type curr = this->index->start(i);
-      if(curr.first != prev.first) { run_id++; prev = curr; }
+      if(curr.first == ENDMARKER || curr.first != prev.first) { run_id++; prev = curr; }
       endmarker_runs[i] = run_id;
     }
   }


### PR DESCRIPTION
Until now, the support for empty paths (node sequences of length 0) has been inconsistent. Early construction algorithms didn't support them, but the restriction was lifted at some point. However, some algorithms still didn't understand them properly.

After this PR, empty paths are fully supported. They should be used with care, as they are unintuitive. Because empty paths are not located anywhere in the graph, algorithms based on, for example, partitioning the graph into components may not handle them properly.