### PR TITLE
Add forget function for temp files

### DIFF
--- a/include/gbwt/utils.h
+++ b/include/gbwt/utils.h
@@ -337,6 +337,8 @@ namespace TempFile
   void setDirectory(const std::string& directory);
   std::string getName(const std::string& name_part);
   void remove(std::string& filename);  // Also clears the filename.
+  // Forget about current temporary files so that they aren't deleted.
+  void forget();
 }
 
 // Returns the total length of the rows, excluding line ends.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -255,6 +255,13 @@ namespace TempFile
       filename.clear();
     }
   }
+
+  void
+  forget() {
+    std::lock_guard<std::mutex> lock(tempfile_lock);
+    handler.filenames.clear();
+    handler.counter = 0;
+  }
 } // namespace TempFile
 
 size_type


### PR DESCRIPTION
This is necessary in forked processes to keep the temp file handler from trying to delete the same files multiple times.