### PR TITLE
Split GBWT by graph components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ remove_seq
 
 # Tests
 test_bwtmerge
+test_gbwt
 test_metadata
 test_queries
 test_support

--- a/include/gbwt/gbwt.h
+++ b/include/gbwt/gbwt.h
@@ -40,7 +40,7 @@ public:
   // `subgraphs` or higher will not be included in the output. The subgraph
   // indexes are only valid if the mapping is consistent with the weakly
   // connected components of the graph.
-  // Splits the metadata and ignores the tags.
+  // Drops empty paths. Splits the metadata and ignores the tags.
   std::vector<GBWT> split(size_type subgraphs, const std::function<size_type(node_type)>& mapping) const;
 
   void swap(GBWT& another);

--- a/include/gbwt/gbwt.h
+++ b/include/gbwt/gbwt.h
@@ -1,28 +1,3 @@
-/*
-  Copyright (c) 2017, 2018, 2019, 2020, 2021 Jouni Siren
-  Copyright (c) 2017 Genome Research Ltd.
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #ifndef GBWT_GBWT_H
 #define GBWT_GBWT_H
 
@@ -57,7 +32,16 @@ public:
 
   // Merge the sources, assuming that node ids do not overlap.
   // Also merges the metadata if all indexes contain it.
+  // Does not merge the tags.
   explicit GBWT(const std::vector<GBWT>& sources);
+
+  // Split the index into the given number of subgraph indexes, according to
+  // the provided mapping from node ids to subgraph ids. Nodes that map to
+  // `subgraphs` or higher will not be included in the output. The subgraph
+  // indexes are only valid if the mapping is consistent with the weakly
+  // connected components of the graph.
+  // Splits the metadata and ignores the tags.
+  std::vector<GBWT> split(size_type subgraphs, const std::function<size_type(node_type)>& mapping) const;
 
   void swap(GBWT& another);
   GBWT& operator=(const GBWT& source);

--- a/include/gbwt/metadata.h
+++ b/include/gbwt/metadata.h
@@ -1,27 +1,3 @@
-/*
-  Copyright (c) 2019, 2020, 2021, 2024, 2025 Jouni Siren
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #ifndef GBWT_METADATA_H
 #define GBWT_METADATA_H
 
@@ -103,6 +79,9 @@ public:
 
   Metadata();
   Metadata(std::vector<const Metadata*> sources, bool same_samples, bool same_contigs);
+
+  // See `GBWT::split()`.
+  void split(size_type subgraphs, const std::vector<size_type>& path_to_subgraph, std::vector<Metadata*>& metadata) const;
 
   size_type serialize(std::ostream& out, sdsl::structure_tree_node* v = nullptr, std::string name = "") const;
   void load(std::istream& in);

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -1,7 +1,7 @@
 #ifndef GBWT_SUPPORT_H
 #define GBWT_SUPPORT_H
 
-#include <gbwt/utils.h>
+#include <gbwt/files.h>
 
 #include <functional>
 #include <map>

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -433,6 +433,7 @@ struct DASamples
   size_type tryLocate(size_type record, size_type offset) const;
 
   // Returns the first sample at >= offset or invalid_sample() if there is no sample.
+  // Continues to report samples in subsequent sampled records.
   sample_type nextSample(size_type record, size_type offset) const;
 
   bool isSampled(size_type record) const { return this->sampled_records[record]; }

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -382,7 +382,7 @@ struct DASamples
 {
   typedef gbwt::size_type size_type;
 
-  // Does node i have samples?
+  // Does record i have samples?
   sdsl::bit_vector                 sampled_records;
   sdsl::bit_vector::rank_1_type    record_rank;
 
@@ -403,9 +403,17 @@ struct DASamples
   explicit DASamples(const std::vector<DynamicRecord>& bwt);
 
   // Assumes that the samples are in sorted order.
-  explicit DASamples(const RecordArray& bwt, const std::vector<std::pair<node_type, sample_type>>& samples);
+  explicit DASamples(const RecordArray& bwt, const std::vector<std::pair<comp_type, sample_type>>& samples);
 
   DASamples(const std::vector<DASamples const*> sources, const sdsl::int_vector<0>& origins, const std::vector<size_type>& record_offsets, const std::vector<size_type>& sequence_counts);
+
+  // See `GBWT::split()`.
+  void split
+  (
+    size_type subgraphs, const std::function<size_type(node_type)>& mapping,
+    size_t alphabet_offset, const DecompressedRecord& endmarker,
+    const std::vector<RecordArray*>& bwts, std::vector<DASamples*>& dasamples
+  ) const;
 
   void swap(DASamples& another);
   DASamples& operator=(const DASamples& source);

--- a/include/gbwt/support.h
+++ b/include/gbwt/support.h
@@ -1,28 +1,3 @@
-/*
-  Copyright (c) 2017, 2018, 2019, 2020, 2021, 2025, 2026 Jouni Siren
-  Copyright (c) 2017 Genome Research Ltd.
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #ifndef GBWT_SUPPORT_H
 #define GBWT_SUPPORT_H
 
@@ -301,6 +276,10 @@ struct DecompressedRecord
   explicit DecompressedRecord(const DynamicRecord& source);
   explicit DecompressedRecord(const CompressedRecord& source);
 
+  // See `GBWT::split()`.
+  // The returned records have no incoming edges or samples.
+  std::vector<DynamicRecord> split(size_type subgraphs, const std::function<size_type(node_type)>& mapping) const;
+
   void swap(DecompressedRecord& another);
   DecompressedRecord& operator=(const DecompressedRecord& source);
   DecompressedRecord& operator=(DecompressedRecord&& source);
@@ -317,6 +296,9 @@ struct DecompressedRecord
 
   // As above, but also sets 'run_end' to the last offset of the current logical run.
   edge_type runLF(size_type i, size_type& run_end) const;
+
+  // As above, but with concrete runs.
+  edge_type concreteRunLF(size_type i, size_type& run_end) const;
 
   // Returns BWT[i] within the record.
   node_type operator[](size_type i) const;
@@ -353,6 +335,14 @@ struct RecordArray
 
   explicit RecordArray(const std::vector<DynamicRecord>& bwt);
   RecordArray(const std::vector<RecordArray const*> sources, const sdsl::int_vector<0>& origins);
+
+  // See `GBWT::split()`.
+  void split
+  (
+    size_type subgraphs, const std::function<size_type(node_type)>& mapping,
+    size_type alphabet_offset, const DecompressedRecord& endmarker,
+    std::vector<GBWTHeader*>& headers, std::vector<RecordArray*>& bwts
+  ) const;
 
   // Set the number of records, build the data manually, and give the offsets to build the index.
   explicit RecordArray(size_type array_size);

--- a/src/gbwt.cpp
+++ b/src/gbwt.cpp
@@ -371,9 +371,9 @@ GBWT::split(size_type subgraphs, const std::function<size_type(node_type)>& mapp
   if(subgraphs == 0) { return result; }
 
   // Split the BWT and update the headers.
+  std::vector<RecordArray*> bwts(subgraphs);
   {
     std::vector<GBWTHeader*> headers(subgraphs);
-    std::vector<RecordArray*> bwts(subgraphs);
     for(size_type i = 0; i < subgraphs; i++)
     {
       headers[i] = &(result[i].header);
@@ -391,8 +391,7 @@ GBWT::split(size_type subgraphs, const std::function<size_type(node_type)>& mapp
   {
     std::vector<DASamples*> da_samples(subgraphs);
     for(size_type i = 0; i < subgraphs; i++) { da_samples[i] = &(result[i].da_samples); }
-    // FIXME: implement this
-    // this->da_samples.split(subgraphs, mapping, da_samples);
+    this->da_samples.split(subgraphs, mapping, this->header.offset, this->endmarker_record, bwts, da_samples);
   }
 
   // Split the metadata.

--- a/src/gbwt.cpp
+++ b/src/gbwt.cpp
@@ -379,8 +379,7 @@ GBWT::split(size_type subgraphs, const std::function<size_type(node_type)>& mapp
       headers[i] = &(result[i].header);
       bwts[i] = &(result[i].bwt);
     }
-    // FIXME: implement this
-    // this->bwt.split(subgraphs, mapping, headers, bwts);
+    this->bwt.split(subgraphs, mapping, this->header.offset, this->endmarker_record, headers, bwts);
     for(size_type i = 0; i < subgraphs; i++)
     {
       if(!(this->bidirectional()) && !(result[i].empty())) { result[i].header.unset(GBWTHeader::FLAG_BIDIRECTIONAL); }

--- a/src/gbwt.cpp
+++ b/src/gbwt.cpp
@@ -383,6 +383,7 @@ GBWT::split(size_type subgraphs, const std::function<size_type(node_type)>& mapp
     for(size_type i = 0; i < subgraphs; i++)
     {
       if(!(this->bidirectional()) && !(result[i].empty())) { result[i].header.unset(GBWTHeader::FLAG_BIDIRECTIONAL); }
+      result[i].cacheEndmarker();
     }
   }
 
@@ -410,15 +411,13 @@ GBWT::split(size_type subgraphs, const std::function<size_type(node_type)>& mapp
     // Then split the metadata itself.
     std::vector<Metadata*> metadata(subgraphs);
     for(size_type i = 0; i < subgraphs; i++) { metadata[i] = &(result[i].metadata); }
-    // FIXME: implement this
-    // this->metadata.split(subgraphs, path_to_subgraph, metadata);
+    this->metadata.split(subgraphs, path_to_subgraph, metadata);
     for(size_type i = 0; i < subgraphs; i++)
     {
       if(!(result[i].empty())) { result[i].addMetadata(); }
     }
   }
 
-  for(size_type i = 0; i < subgraphs; i++) { result[i].cacheEndmarker(); }
   return result;
 }
 

--- a/src/gbwt.cpp
+++ b/src/gbwt.cpp
@@ -1,28 +1,3 @@
-/*
-  Copyright (c) 2017, 2019, 2020, 2021, 2025 Jouni Siren
-  Copyright (c) 2017 Genome Research Ltd.
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #include <gbwt/gbwt.h>
 
 #include <gbwt/dynamic_gbwt.h>
@@ -387,6 +362,65 @@ GBWT::GBWT(const std::vector<GBWT>& sources)
   }
 
   this->cacheEndmarker();
+}
+
+std::vector<GBWT>
+GBWT::split(size_type subgraphs, const std::function<size_type(node_type)>& mapping) const
+{
+  std::vector<GBWT> result(subgraphs);
+  if(subgraphs == 0) { return result; }
+
+  // Split the BWT and update the headers.
+  {
+    std::vector<GBWTHeader*> headers(subgraphs);
+    std::vector<RecordArray*> bwts(subgraphs);
+    for(size_type i = 0; i < subgraphs; i++)
+    {
+      headers[i] = &(result[i].header);
+      bwts[i] = &(result[i].bwt);
+    }
+    // FIXME: implement this
+    // this->bwt.split(subgraphs, mapping, headers, bwts);
+    for(size_type i = 0; i < subgraphs; i++)
+    {
+      if(!(this->bidirectional()) && !(result[i].empty())) { result[i].header.unset(GBWTHeader::FLAG_BIDIRECTIONAL); }
+    }
+  }
+
+  // Split the DA samples.
+  {
+    std::vector<DASamples*> da_samples(subgraphs);
+    for(size_type i = 0; i < subgraphs; i++) { da_samples[i] = &(result[i].da_samples); }
+    // FIXME: implement this
+    // this->da_samples.split(subgraphs, mapping, da_samples);
+  }
+
+  // Split the metadata.
+  if(this->hasMetadata())
+  {
+    // First assign the paths to subgraphs.
+    size_type paths = (this->bidirectional() ? this->sequences() / 2 : this->sequences());
+    size_type increment = (this->bidirectional() ? 2 : 1);
+    std::vector<size_type> path_to_subgraph(paths, subgraphs);
+    for(size_type path_id = 0, seq_id = 0; path_id < paths; path_id++, seq_id += increment)
+    {
+      edge_type start = this->start(seq_id);
+      path_to_subgraph[path_id] = mapping(start.first);
+    }
+
+    // Then split the metadata itself.
+    std::vector<Metadata*> metadata(subgraphs);
+    for(size_type i = 0; i < subgraphs; i++) { metadata[i] = &(result[i].metadata); }
+    // FIXME: implement this
+    // this->metadata.split(subgraphs, path_to_subgraph, metadata);
+    for(size_type i = 0; i < subgraphs; i++)
+    {
+      if(!(result[i].empty())) { result[i].addMetadata(); }
+    }
+  }
+
+  for(size_type i = 0; i < subgraphs; i++) { result[i].cacheEndmarker(); }
+  return result;
 }
 
 //------------------------------------------------------------------------------

--- a/src/metadata.cpp
+++ b/src/metadata.cpp
@@ -1,27 +1,3 @@
-/*
-  Copyright (c) 2019, 2020, 2021, 2024, 2025 Jouni Siren
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #include <gbwt/internal.h>
 #include <gbwt/metadata.h>
 
@@ -619,6 +595,81 @@ Metadata::merge(const Metadata& source, bool same_samples, bool same_contigs)
       std::cerr << "Metadata::merge(): Warning: Clearing path names; the source has no path names" << std::endl;
     }
     this->clearPathNames();
+  }
+}
+
+void
+Metadata::split(size_type subgraphs, const std::vector<size_type>& path_to_subgraph, std::vector<Metadata*>& metadata) const
+{
+  if(!(this->hasPathNames()))
+  {
+    // We cannot do anything meaningful without path names.
+    if(Verbosity::level >= Verbosity::FULL)
+    {
+      std::cerr << "Metadata::split(): Warning: Cannot split metadata without path names" << std::endl;
+    }
+    return;
+  }
+
+  // Split the paths and determine sample/contig ids and haplotype counts for each subgraph.
+  std::vector<std::unordered_map<size_type, size_type>> sample_id_maps(subgraphs);
+  std::vector<std::unordered_map<size_type, size_type>> contig_id_maps(subgraphs);
+  std::vector<std::set<std::pair<size_type, size_type>>> haplotypes(subgraphs);
+  for(size_type i = 0; i < this->paths(); i++)
+  {
+    PathName path = this->path(i);
+    size_type subgraph = path_to_subgraph[i];
+    if(subgraph >= subgraphs) { continue; }
+
+    auto result = sample_id_maps[subgraph].try_emplace(path.sample, sample_id_maps[subgraph].size());
+    path.sample = result.first->second;
+    result = contig_id_maps[subgraph].try_emplace(path.contig, contig_id_maps[subgraph].size());
+    path.contig = result.first->second;
+
+    haplotypes[subgraph].emplace(path.sample, path.phase);
+    metadata[subgraph]->addPath(path);
+  }
+
+  // Samples.
+  for(size_type i = 0; i < subgraphs; i++)
+  {
+    if(this->hasSampleNames())
+    {
+      std::vector<std::string> sample_names(sample_id_maps[i].size());
+      for(const auto& sample_pair : sample_id_maps[i])
+      {
+        sample_names[sample_pair.second] = this->sample_names[sample_pair.first];
+      }
+      metadata[i]->setSamples(sample_names);
+    }
+    else
+    {
+      metadata[i]->setSamples(sample_id_maps[i].size());
+    }
+  }
+
+  // Contigs.
+  for(size_type i = 0; i < subgraphs; i++)
+  {
+    if(this->hasContigNames())
+    {
+      std::vector<std::string> contig_names(contig_id_maps[i].size());
+      for(const auto& contig_pair : contig_id_maps[i])
+      {
+        contig_names[contig_pair.second] = this->contig_names[contig_pair.first];
+      }
+      metadata[i]->setContigs(contig_names);
+    }
+    else
+    {
+      metadata[i]->setContigs(contig_id_maps[i].size());
+    }
+  }
+
+  // Haplotypes.
+  for(size_type i = 0; i < subgraphs; i++)
+  {
+    metadata[i]->setHaplotypes(haplotypes[i].size());
   }
 }
 

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1481,6 +1481,85 @@ DASamples::DASamples(const std::vector<DASamples const*> sources, const sdsl::in
 }
 
 void
+DASamples::split
+(
+  size_type subgraphs, const std::function<size_type(node_type)>& mapping,
+  size_t alphabet_offset, const DecompressedRecord& endmarker,
+  const std::vector<RecordArray*>& bwts, std::vector<DASamples*>& dasamples
+) const
+{
+  std::vector<std::vector<std::pair<comp_type, sample_type>>> subgraph_samples(subgraphs);
+  std::vector<size_type> seq_counts(subgraphs, 0);
+  std::unordered_map<size_type, std::pair<size_type, size_type>> seq_mapping; // seq_id -> (subgraph, local_seq_id)
+
+  // Assign sequences to subgraphs.
+  for(size_type i = 0; i < endmarker.size(); i++)
+  {
+    edge_type edge = endmarker.LF(i);
+    size_type to = mapping(edge.first);
+    if(to < subgraphs)
+    {
+      seq_mapping[i] = std::make_pair(to, seq_counts[to]);
+      seq_counts[to]++;
+    }
+  }
+  seq_counts = std::vector<size_type>(); // Clear the vector to save memory.
+
+  // Special handling for the endmarker, which is shared between the subgraphs.
+  if(this->isSampled(ENDMARKER))
+  {
+    size_type offset = 0;
+    while(true)
+    {
+      sample_type sample = this->nextSample(ENDMARKER, offset);
+      if(sample == invalid_sample()) { break; }
+      size_type seq_id = sample.second;
+      auto iter = seq_mapping.find(seq_id);
+      if(iter != seq_mapping.end())
+      {
+        size_type to = iter->second.first;
+        size_type local_seq_id = iter->second.second;
+        subgraph_samples[to].push_back(std::make_pair(0, sample_type(local_seq_id, local_seq_id)));
+      }
+      offset = sample.first + 1;
+    }
+  }
+
+  // Assign the records to subgraphs and translate the samples.
+  std::vector<comp_type> record_counts(subgraphs, 1); // Every subgraph already has the endmarker record.
+  for(comp_type comp = 1; comp < this->size(); comp++)
+  {
+    size_type to = mapping(comp + alphabet_offset);
+    if(to >= subgraphs) { continue; }
+    comp_type local_comp = record_counts[to];
+    record_counts[to]++;
+    if(!this->isSampled(comp)) { continue; }
+    size_type offset = 0;
+    while(true)
+    {
+      sample_type sample = this->nextSample(comp, offset);
+      if(sample == invalid_sample()) { break; }
+      size_type seq_id = sample.second;
+      auto iter = seq_mapping.find(seq_id);
+      if(iter != seq_mapping.end())
+      {
+        size_type local_seq_id = iter->second.second;
+        subgraph_samples[to].push_back(std::make_pair(local_comp, sample_type(sample.first, local_seq_id)));
+      }
+      offset = sample.first + 1;
+    }
+  }
+  seq_mapping = std::unordered_map<size_type, std::pair<size_type, size_type>>(); // Clear the map to save memory.
+  record_counts = std::vector<comp_type>(); // Clear the vector to save memory.
+
+  for(size_type i = 0; i < subgraphs; i++)
+  {
+    *dasamples[i] = DASamples(*bwts[i], subgraph_samples[i]);
+    subgraph_samples[i] = std::vector<std::pair<comp_type, sample_type>>(); // Clear the vector to save memory.
+  }
+}
+
+void
 DASamples::swap(DASamples& another)
 {
   if(this != &another)

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1078,9 +1078,10 @@ RecordArray::split
     node_type node = comp + alphabet_offset;
     size_type to = mapping(node);
     if(to >= subgraphs) { continue; }
+
+    // Pad with empty records if necessary and update alphabet information in the header.
     if(last_node[to] != ENDMARKER)
     {
-      // Add empty records between the last node and the current node.
       for(node_type empty = last_node[to] + 1; empty < node; empty++)
       {
         offsets[to].push_back(bwts[to]->data.size());
@@ -1090,6 +1091,9 @@ RecordArray::split
     }
     else { headers[to]->offset = node - 1; }
     headers[to]->alphabet_size = node + 1;
+    last_node[to] = node;
+
+    // Now write the actual record.
     offsets[to].push_back(bwts[to]->data.size());
     size_type source_start = iter->second;
     ++iter;
@@ -1100,7 +1104,6 @@ RecordArray::split
     bwts[to]->records++;
     CompressedRecord record(bwts[to]->data, target_start, target_limit);
     headers[to]->size += record.size();
-    last_node[to] = node;
   }
 
   // Build indexes for the BWTs.

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1075,6 +1075,8 @@ RecordArray::split
   ++iter; // Skip the endmarker record.
   for(comp_type comp = 1; comp < this->records; comp++)
   {
+    size_type source_start = iter->second; ++iter;
+    size_type source_limit = iter->second;
     node_type node = comp + alphabet_offset;
     size_type to = mapping(node);
     if(to >= subgraphs) { continue; }
@@ -1095,9 +1097,6 @@ RecordArray::split
 
     // Now write the actual record.
     offsets[to].push_back(bwts[to]->data.size());
-    size_type source_start = iter->second;
-    ++iter;
-    size_type source_limit = iter->second;
     size_type target_start = bwts[to]->data.size();
     bwts[to]->data.insert(bwts[to]->data.end(), this->data.begin() + source_start, this->data.begin() + source_limit);
     size_type target_limit = bwts[to]->data.size();
@@ -1512,7 +1511,7 @@ DASamples::split
     while(true)
     {
       sample_type sample = this->nextSample(ENDMARKER, offset);
-      if(sample == invalid_sample()) { break; }
+      if(sample == invalid_sample() || sample.first >= endmarker.size()) { break; }
       size_type seq_id = sample.second;
       auto iter = seq_mapping.find(seq_id);
       if(iter != seq_mapping.end())
@@ -1527,18 +1526,18 @@ DASamples::split
 
   // Assign the records to subgraphs and translate the samples.
   std::vector<comp_type> record_counts(subgraphs, 1); // Every subgraph already has the endmarker record.
-  for(comp_type comp = 1; comp < this->size(); comp++)
+  for(comp_type comp = 1; comp < this->records(); comp++)
   {
     size_type to = mapping(comp + alphabet_offset);
     if(to >= subgraphs) { continue; }
     comp_type local_comp = record_counts[to];
     record_counts[to]++;
     if(!this->isSampled(comp)) { continue; }
-    size_type offset = 0;
+    size_type offset = 0, record_size = bwts[to]->size(local_comp);
     while(true)
     {
       sample_type sample = this->nextSample(comp, offset);
-      if(sample == invalid_sample()) { break; }
+      if(sample == invalid_sample() || sample.first >= record_size) { break; }
       size_type seq_id = sample.second;
       auto iter = seq_mapping.find(seq_id);
       if(iter != seq_mapping.end())

--- a/src/support.cpp
+++ b/src/support.cpp
@@ -1,28 +1,6 @@
-/*
-  Copyright (c) 2017, 2018, 2019, 2020, 2021, 2025, 2026 Jouni Siren
-  Copyright (c) 2017 Genome Research Ltd.
+#include <gbwt/support.h>
 
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
+#include <gbwt/files.h>
 #include <gbwt/internal.h>
 
 #include <cctype>
@@ -832,6 +810,28 @@ DecompressedRecord::DecompressedRecord(const CompressedRecord& source) :
   }
 }
 
+std::vector<DynamicRecord>
+DecompressedRecord::split(size_type subgraphs, const std::function<size_type(node_type)>& mapping) const
+{
+  std::vector<DynamicRecord> result(subgraphs);
+  size_type start = 0, limit = 0;
+  while(limit < this->size())
+  {
+    edge_type next = this->concreteRunLF(start, limit);
+    limit++; // Now at the start of the next run.
+    size_type to = mapping(next.first);
+    if(to < subgraphs)
+    {
+      result[to].body_size += (limit - start);
+      rank_type outrank = result[to].edgeToLinear(next.first);
+      if(outrank >= result[to].outdegree()) { result[to].outgoing.push_back(next); }
+      result[to].body.push_back(run_type(outrank, limit - start));
+    }
+    start = limit;
+  }
+  return result;
+}
+
 void
 DecompressedRecord::swap(DecompressedRecord& another)
 {
@@ -903,6 +903,17 @@ DecompressedRecord::runLF(size_type i, size_type& run_end) const
   {
     while(run_end + 1 < this->size() && this->body[run_end + 1].first == this->body[i].first) { run_end++; }
   }
+
+  return this->body[i];
+}
+
+edge_type
+DecompressedRecord::concreteRunLF(size_type i, size_type& run_end) const
+{
+  if(i >= this->size()) { return invalid_edge(); }
+
+  run_end = i;
+  while(run_end + 1 < this->size() && this->body[run_end + 1].first == this->body[i].first) { run_end++; }
 
   return this->body[i];
 }
@@ -1030,6 +1041,74 @@ RecordArray::RecordArray(const std::vector<RecordArray const*> sources, const sd
   this->buildIndex(offsets);
 }
 
+void
+RecordArray::split
+(
+  size_type subgraphs, const std::function<size_type(node_type)>& mapping,
+  size_type alphabet_offset, const DecompressedRecord& endmarker,
+  std::vector<GBWTHeader*>& headers, std::vector<RecordArray*>& bwts
+) const
+{
+  if(this->empty()) { return; }
+  std::vector<std::vector<size_type>> offsets(subgraphs);
+  std::vector<node_type> last_node(subgraphs, ENDMARKER);
+
+  // Split the endmarker record.
+  {
+    std::vector<DynamicRecord> parts = endmarker.split(subgraphs, mapping);
+    for(size_type i = 0; i < subgraphs; i++)
+    {
+      if(!(parts[i].empty()))
+      {
+        headers[i]->sequences = parts[i].size();
+        headers[i]->size = parts[i].size();
+        offsets[i].push_back(0);
+        parts[i].recode();
+        parts[i].writeBWT(bwts[i]->data);
+        bwts[i]->records = 1;
+      }
+    }
+  }
+
+  // Assign records to output BWTs.
+  auto iter = this->index.one_begin();
+  ++iter; // Skip the endmarker record.
+  for(comp_type comp = 1; comp < this->records; comp++)
+  {
+    node_type node = comp + alphabet_offset;
+    size_type to = mapping(node);
+    if(to >= subgraphs) { continue; }
+    if(last_node[to] != ENDMARKER)
+    {
+      // Add empty records between the last node and the current node.
+      for(node_type empty = last_node[to] + 1; empty < node; empty++)
+      {
+        offsets[to].push_back(bwts[to]->data.size());
+        bwts[to]->data.push_back(0);
+        bwts[to]->records++;
+      }
+    }
+    else { headers[to]->offset = node - 1; }
+    headers[to]->alphabet_size = node + 1;
+    offsets[to].push_back(bwts[to]->data.size());
+    size_type source_start = iter->second;
+    ++iter;
+    size_type source_limit = iter->second;
+    size_type target_start = bwts[to]->data.size();
+    bwts[to]->data.insert(bwts[to]->data.end(), this->data.begin() + source_start, this->data.begin() + source_limit);
+    size_type target_limit = bwts[to]->data.size();
+    bwts[to]->records++;
+    CompressedRecord record(bwts[to]->data, target_start, target_limit);
+    headers[to]->size += record.size();
+    last_node[to] = node;
+  }
+
+  // Build indexes for the BWTs.
+  for(size_type i = 0; i < subgraphs; i++)
+  {
+    if(!(bwts[i]->empty())) { bwts[i]->buildIndex(offsets[i]); }
+  }
+}
 
 RecordArray::RecordArray(size_type array_size) :
   records(array_size)

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -62,7 +62,7 @@ endif
 CXX_FLAGS=$(MY_CXX_FLAGS) $(PARALLEL_FLAGS) $(MY_CXX_OPT_FLAGS) $(INCLUDES)
 
 HEADERS=$(wildcard $(MAIN_DIR)/include/gbwt/*.h)
-PROGRAMS=test_utils test_support test_bwtmerge test_metadata test_queries test_variants
+PROGRAMS=test_utils test_support test_metadata test_gbwt test_bwtmerge test_queries test_variants
 
 .PHONY: all clean test
 all:$(PROGRAMS)

--- a/tests/test_gbwt.cpp
+++ b/tests/test_gbwt.cpp
@@ -1,0 +1,237 @@
+#include <gtest/gtest.h>
+
+#include <set>
+#include <unordered_map>
+
+#include <gbwt/dynamic_gbwt.h>
+
+using namespace gbwt;
+
+namespace
+{
+
+//------------------------------------------------------------------------------
+
+class MergeSplitTest : public ::testing::Test
+{
+public:
+  std::vector<vector_type> first_paths, second_paths;
+  std::vector<FullPathName> first_path_names, second_path_names;
+
+  vector_type createPath(const std::vector<std::pair<node_type, bool>>& nodes) const
+  {
+    vector_type result;
+    for(const std::pair<node_type, bool>& node_visit : nodes)
+    {
+      result.push_back(Node::encode(node_visit.first, node_visit.second));
+    }
+    return result;
+  }
+
+  // This is the components_ref test case from GBWTGraph.
+  void SetUp() override
+  {
+    this->first_paths =
+    {
+      createPath({ { 11, false }, { 13, false }, { 14, false}, { 15, false }, { 17, false } }),
+      createPath({ { 11, false }, { 12, false }, { 14, false}, { 15, false }, { 17, false } }),
+      createPath({ { 11, false }, { 13, false }, { 14, false}, { 16, false }, { 17, false } }),
+    };
+    this->second_paths =
+    {
+      createPath({ { 21, false }, { 23, false }, { 24, true }, { 22, true }, { 21, true } }),
+      createPath({ { 21, false }, { 22, false }, { 24, false }, { 23, true }, { 21, true } }),
+      createPath({ { 21, false }, { 22, false }, { 24, false }, { 25, false } }),
+    };
+
+    this->first_path_names =
+    {
+      FullPathName { "ref", "A", 0, 0 }, FullPathName { "sample", "A", 1, 0 }, FullPathName { "sample", "A", 2, 0 }
+    };
+    this->second_path_names =
+    {
+      FullPathName { "ref", "B", 0, 0 }, FullPathName { "sample", "B", 1, 0 }, FullPathName { "sample", "B", 2, 0 }
+    };
+  }
+
+  GBWT buildGBWT(const std::vector<vector_type>& paths, const std::vector<FullPathName>& path_names, bool bidirectional) const
+  {
+    size_type total_length = 0;
+    for(const vector_type& path : paths) { total_length += path.size(); }
+    total_length += paths.size(); // Endmarkers.
+    if(bidirectional) { total_length *= 2; }
+
+    // 32 bits should be enough, because we always compile with GBWT_SAVE_MEMORY.
+    // We sample every other position to be able to test the edge cases with merging/splitting DASamples.
+    GBWTBuilder builder(32, total_length, 2);
+    for(const vector_type& path : paths) { builder.insert(path, bidirectional); }
+    builder.finish();
+    GBWT index(builder.index);
+    index.addMetadata();
+
+    // TODO: We should integrate metadata construction in the builder.
+    std::unordered_map<std::string, size_type> sample_mapping, contig_mapping;
+    std::vector<std::string> sample_names, contig_names;
+    std::set<std::pair<size_type, size_type>> haplotypes;
+    for(const FullPathName& name : path_names)
+    {
+      auto sample_result = sample_mapping.try_emplace(name.sample_name, sample_mapping.size());
+      if(sample_result.second) { sample_names.push_back(name.sample_name); }
+      auto contig_result = contig_mapping.try_emplace(name.contig_name, contig_mapping.size());
+      if(contig_result.second) { contig_names.push_back(name.contig_name); }
+      haplotypes.insert(std::make_pair(name.haplotype, name.offset));
+    }
+    index.metadata.setSamples(sample_names);
+    index.metadata.setContigs(contig_names);
+    index.metadata.setHaplotypes(haplotypes.size());
+    for(size_type i = 0; i < path_names.size(); i++)
+    {
+      const FullPathName& name = path_names[i];
+      size_type sample_id = sample_mapping[name.sample_name];
+      size_type contig_id = contig_mapping[name.contig_name];
+      index.metadata.addPath(sample_id, contig_id, name.haplotype, name.offset);
+    }
+
+    return index;
+  }
+
+  void compareGBWTs(const GBWT& index, const GBWT& truth, const std::string& test_case_name) const
+  {
+    std::string test_case = (test_case_name.empty() ? std::string() : std::string(" in ") + test_case_name);
+
+    bool same_header = (index.header == truth.header);
+    if(!same_header)
+    {
+      EXPECT_EQ(index.header.sequences, truth.header.sequences) << "Wrong number of sequences in GBWT header" << test_case;
+      EXPECT_EQ(index.header.size, truth.header.size) << "Wrong size in GBWT header" << test_case;
+      EXPECT_EQ(index.header.offset, truth.header.offset) << "Wrong offset in GBWT header" << test_case;
+      EXPECT_EQ(index.header.alphabet_size, truth.header.alphabet_size) << "Wrong alphabet size in GBWT header" << test_case;
+      EXPECT_EQ(index.header.flags, truth.header.flags) << "Wrong flags in GBWT header" << test_case;
+    }
+    ASSERT_TRUE(same_header) << "Wrong GBWT header" << test_case;
+
+    bool same_tags = (index.tags == truth.tags);
+    ASSERT_TRUE(same_tags) << "Wrong GBWT tags" << test_case;
+
+    bool same_recordarray_index = (index.bwt.index == truth.bwt.index);
+    ASSERT_TRUE(same_recordarray_index) << "Wrong index for GBWT records" << test_case;
+    bool same_recordarray_data = (index.bwt.data == truth.bwt.data);
+    ASSERT_TRUE(same_recordarray_data) << "Wrong data for GBWT records" << test_case;
+
+    bool same_dasamples_sampled = (index.da_samples.sampled_records == truth.da_samples.sampled_records);
+    ASSERT_TRUE(same_dasamples_sampled) << "Wrong sampled records in DA samples" << test_case;
+    bool same_dasamples_ranges = (index.da_samples.bwt_ranges == truth.da_samples.bwt_ranges);
+    ASSERT_TRUE(same_dasamples_ranges) << "Wrong BWT ranges in DA samples" << test_case;
+    bool same_dasamples_offsets = (index.da_samples.sampled_offsets == truth.da_samples.sampled_offsets);
+    ASSERT_TRUE(same_dasamples_offsets) << "Wrong sampled offsets in DA samples" << test_case;
+    bool same_dasamples_samples = (index.da_samples.array == truth.da_samples.array);
+    ASSERT_TRUE(same_dasamples_samples) << "Wrong samples in DA samples" << test_case;
+
+    bool same_metadata = (index.metadata == truth.metadata);
+    if(!same_metadata)
+    {
+      EXPECT_EQ(index.metadata.samples(), truth.metadata.samples()) << "Wrong number of samples in GBWT metadata" << test_case;
+      EXPECT_EQ(index.metadata.haplotypes(), truth.metadata.haplotypes()) << "Wrong number of haplotypes in GBWT metadata" << test_case;
+      EXPECT_EQ(index.metadata.contigs(), truth.metadata.contigs()) << "Wrong number of contigs in GBWT metadata" << test_case;
+      EXPECT_EQ(index.metadata.paths(), truth.metadata.paths()) << "Wrong number of paths in GBWT metadata" << test_case;
+      EXPECT_EQ(index.metadata.hasPathNames(), truth.metadata.hasPathNames()) << "Wrong path name flag in GBWT metadata" << test_case;
+      EXPECT_EQ(index.metadata.hasSampleNames(), truth.metadata.hasSampleNames()) << "Wrong sample name flag in GBWT metadata" << test_case;
+      EXPECT_EQ(index.metadata.hasContigNames(), truth.metadata.hasContigNames()) << "Wrong contig name flag in GBWT metadata" << test_case;
+    }
+    ASSERT_TRUE(same_metadata) << "Wrong GBWT metadata" << test_case;
+  }
+};
+
+TEST_F(MergeSplitTest, Merge)
+{
+  for(const auto& test_case : { std::make_pair(false, "unidirectional"), std::make_pair(true, "bidirectional") })
+  {
+    bool bidirectional = test_case.first;
+    const std::string& test_case_name = test_case.second;
+
+    GBWT first = this->buildGBWT(this->first_paths, this->first_path_names, bidirectional);
+    GBWT second = this->buildGBWT(this->second_paths, this->second_path_names, bidirectional);
+    GBWT merged({ first, second });
+
+    std::vector<vector_type> merged_paths = this->first_paths;
+    merged_paths.insert(merged_paths.end(), this->second_paths.begin(), this->second_paths.end());
+    std::vector<FullPathName> merged_path_names = this->first_path_names;
+    merged_path_names.insert(merged_path_names.end(), this->second_path_names.begin(), this->second_path_names.end());
+    GBWT truth = this->buildGBWT(merged_paths, merged_path_names, bidirectional);
+
+    this->compareGBWTs(merged, truth, test_case_name);
+  }
+}
+
+TEST_F(MergeSplitTest, Split)
+{
+  for(const auto& test_case : { std::make_pair(false, "unidirectional"), std::make_pair(true, "bidirectional") })
+  {
+    bool bidirectional = test_case.first;
+    const std::string& test_case_name = test_case.second;
+
+    std::vector<vector_type> merged_paths = this->first_paths;
+    merged_paths.insert(merged_paths.end(), this->second_paths.begin(), this->second_paths.end());
+    std::vector<FullPathName> merged_path_names = this->first_path_names;
+    merged_path_names.insert(merged_path_names.end(), this->second_path_names.begin(), this->second_path_names.end());
+    GBWT merged = this->buildGBWT(merged_paths, merged_path_names, bidirectional);
+
+    size_t subgraphs = 2;
+    std::vector<GBWT> parts = merged.split(subgraphs, [&](node_type node) -> size_type
+    {
+      if(node >= Node::encode(11, false) && node <= Node::encode(17, bidirectional)) { return 0; }
+      if(node >= Node::encode(21, false) && node <= Node::encode(25, bidirectional)) { return 1; }
+      return subgraphs;
+    });
+    ASSERT_EQ(parts.size(), subgraphs) << "Wrong number of subgraph indexes in " << test_case_name;
+
+    GBWT first_truth = this->buildGBWT(this->first_paths, this->first_path_names, bidirectional);
+    GBWT second_truth = this->buildGBWT(this->second_paths, this->second_path_names, bidirectional);
+
+    std::string first_name(test_case_name); first_name += " (first)";
+    this->compareGBWTs(parts[0], first_truth, first_name);
+    std::string second_name(test_case_name); second_name += " (second)";
+    this->compareGBWTs(parts[1], second_truth, second_name);
+  }
+}
+
+TEST_F(MergeSplitTest, SplitSingle)
+{
+  for(const auto& test_case : { std::make_pair(false, "unidirectional"), std::make_pair(true, "bidirectional") })
+  {
+    bool bidirectional = test_case.first;
+    const std::string& test_case_name = test_case.second;
+    size_t subgraphs = 1;
+    auto node_to_subgraph = [&](node_type node) -> size_type
+    {
+      if(node >= Node::encode(11, false) && node <= Node::encode(17, bidirectional)) { return 0; }
+      if(node >= Node::encode(21, false) && node <= Node::encode(25, bidirectional)) { return 1; }
+      return 2;
+    };
+
+    std::vector<vector_type> merged_paths = this->first_paths;
+    merged_paths.insert(merged_paths.end(), this->second_paths.begin(), this->second_paths.end());
+    std::vector<FullPathName> merged_path_names = this->first_path_names;
+    merged_path_names.insert(merged_path_names.end(), this->second_path_names.begin(), this->second_path_names.end());
+    GBWT merged = this->buildGBWT(merged_paths, merged_path_names, bidirectional);
+
+    std::vector<GBWT> truths;
+    truths.push_back(this->buildGBWT(this->first_paths, this->first_path_names, bidirectional));
+    truths.push_back(this->buildGBWT(this->second_paths, this->second_path_names, bidirectional));
+
+    for(node_type part : { 0, 1 })
+    {
+      std::string name(test_case_name); name += " (part " + std::to_string(part) + ")";
+      std::vector<GBWT> parts = merged.split(subgraphs, [&](node_type node) -> size_type
+      {
+        return (node_to_subgraph(node) == part ? 0 : 1);
+      });
+      ASSERT_EQ(parts.size(), subgraphs) << "Wrong number of subgraph indexes in " << name;
+      this->compareGBWTs(parts[0], truths[part], name);
+    }
+  }
+}
+
+//------------------------------------------------------------------------------
+
+} // namespace

--- a/tests/test_metadata.cpp
+++ b/tests/test_metadata.cpp
@@ -1,27 +1,3 @@
-/*
-  Copyright (c) 2019, 2021, 2024, 2025 Jouni Siren
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #include <gtest/gtest.h>
 
 #include <random>
@@ -89,6 +65,18 @@ public:
     std::vector<const Metadata*> sources { &first, &second };
     Metadata constructed(sources, same_samples, same_contigs);
     EXPECT_EQ(constructed, correct_result) << "Merge constructor does not work correctly " << test_name;
+  }
+
+  void testSplit(const Metadata& metadata, const std::vector<Metadata*>& correct_result, const std::vector<size_type>& path_to_subgraph, const std::string& test_name) const
+  {
+    std::vector<Metadata*> result(correct_result.size());
+    for(size_type i = 0; i < correct_result.size(); i++) { result[i] = new Metadata(); }
+    metadata.split(correct_result.size(), path_to_subgraph, result);
+    for(size_type i = 0; i < correct_result.size(); i++)
+    {
+      EXPECT_EQ(*result[i], *correct_result[i]) << "Split failed for component " << i << " in " << test_name;
+      delete result[i];
+    }
   }
 
   // first[start, limit) should be equal to second.
@@ -626,6 +614,74 @@ TEST_F(MetadataTest, PathMerging)
   comparePaths(first_names, third_names, false);
   comparePaths(first_nonames, third_nonames, true);
   comparePaths(first_nonames, third_nonames, false);
+}
+
+TEST_F(MetadataTest, PathSplitting)
+{
+  Metadata first_names, first_nonames, second_names, second_nonames;
+
+  first_names.setSamples({ "sample1", "sample2", "sample3" });
+  first_nonames.setSamples(3);
+  first_names.setContigs({ "contig1", "contig2" });
+  first_nonames.setContigs(2);
+
+  second_names.setSamples({ "sample1", "sample3" });
+  second_nonames.setSamples(2);
+  second_names.setContigs({ "contig3", "contig4" });
+  second_nonames.setContigs(2);
+
+  std::vector<size_type> all_components, first_only, second_only;
+
+  first_names.addPath(0, 0, 0, 0); // sample1, contig1
+  first_names.addPath(0, 1, 0, 0); // sample1, contig2
+  first_names.addPath(1, 0, 0, 0); // sample2, contig1
+  first_names.addPath(1, 1, 0, 0); // sample2, contig2
+  first_names.addPath(2, 0, 0, 0); // sample3, contig1
+  first_names.addPath(2, 1, 0, 0); // sample3, contig2
+  for(size_type i = 0; i < first_names.paths(); i++)
+  {
+    first_nonames.addPath(first_names.path(i));
+    all_components.push_back(0);
+    first_only.push_back(0); second_only.push_back(1);
+  }
+
+  second_names.addPath(0, 0, 0, 0); // sample1, contig3
+  second_names.addPath(0, 1, 0, 0); // sample1, contig4
+  second_names.addPath(1, 0, 0, 0); // sample3, contig3
+  second_names.addPath(1, 1, 0, 0); // sample3, contig4
+  for(size_type i = 0; i < second_names.paths(); i++)
+  {
+    second_nonames.addPath(second_names.path(i));
+    all_components.push_back(1);
+    first_only.push_back(1); second_only.push_back(0);
+  }
+
+  first_names.setHaplotypes(first_names.samples());
+  first_nonames.setHaplotypes(first_nonames.samples());
+  second_names.setHaplotypes(second_names.samples());
+  second_nonames.setHaplotypes(second_nonames.samples());
+
+  // Merge and split with sample/contig names.
+  {
+    Metadata merged({ &first_names, &second_names }, false, false);
+    ASSERT_EQ(merged.samples(), size_type(3)) << "Wrong number of samples in merged metadata with names";
+    ASSERT_EQ(merged.contigs(), size_type(4)) << "Wrong number of contigs in merged metadata with names";
+    ASSERT_EQ(merged.paths(), first_names.paths() + second_names.paths()) << "Wrong number of paths in merged metadata with names";
+    testSplit(merged, { &first_names, &second_names }, all_components, "all components with names");
+    testSplit(merged, { &first_names }, first_only, "first only with names");
+    testSplit(merged, { &second_names }, second_only, "second only with names");
+  }
+
+  // Merge and split without sample/contig names.
+  {
+    Metadata merged({ &first_nonames, &second_nonames }, false, false);
+    ASSERT_EQ(merged.samples(), size_type(5)) << "Wrong number of samples in merged metadata without names";
+    ASSERT_EQ(merged.contigs(), size_type(4)) << "Wrong number of contigs in merged metadata without names";
+    ASSERT_EQ(merged.paths(), first_nonames.paths() + second_nonames.paths()) << "Wrong number of paths in merged metadata without names";
+    testSplit(merged, { &first_nonames, &second_nonames }, all_components, "all components without names");
+    testSplit(merged, { &first_nonames }, first_only, "first only without names");
+    testSplit(merged, { &second_nonames }, second_only, "second only without names");
+  }
 }
 
 TEST_F(MetadataTest, Serialization)

--- a/tests/test_support.cpp
+++ b/tests/test_support.cpp
@@ -1,27 +1,3 @@
-/*
-  Copyright (c) 2019, 2021, 2025, 2026 Jouni Siren
-
-  Author: Jouni Siren <jouni.siren@iki.fi>
-
-  Permission is hereby granted, free of charge, to any person obtaining a copy
-  of this software and associated documentation files (the "Software"), to deal
-  in the Software without restriction, including without limitation the rights
-  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-  copies of the Software, and to permit persons to whom the Software is
-  furnished to do so, subject to the following conditions:
-
-  The above copyright notice and this permission notice shall be included in all
-  copies or substantial portions of the Software.
-
-  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-  SOFTWARE.
-*/
-
 #include <gtest/gtest.h>
 
 #include <random>


### PR DESCRIPTION
Adds a function `GBWT::split()` for splitting the GBWT into a number of partial indexes. Each partial index corresponds to a set of weakly connected components in the underlying graph, and the sets must be disjoint.

Splitting can be used as the inverse of the merge constructor (fast merging algorithm). Metadata will be preserved if path names are present. Tags will be lost in splitting.